### PR TITLE
get paths from yang file

### DIFF
--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -40,16 +40,9 @@ var capabilitiesCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		addresses := viper.GetStringSlice("address")
-		addresses, err = selectManyWithAddFromList("select targets", addresses)
+		addresses, err = selectTargets(addresses)
 		if err != nil {
 			return err
-		}
-		if len(addresses) == 0 {
-			fmt.Println("no grpc server address specified")
-			return nil
-		}
-		if addresses[0] == "ALL" {
-			addresses = viper.GetStringSlice("address")
 		}
 		username := viper.GetString("username")
 		if username == "" {

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -45,6 +45,7 @@ var capabilitiesCmd = &cobra.Command{
 			return err
 		}
 		if len(addresses) == 0 {
+			fmt.Println("no grpc server address specified")
 			return nil
 		}
 		if addresses[0] == "ALL" {

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -40,6 +40,16 @@ var capabilitiesCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		addresses := viper.GetStringSlice("address")
+		addresses, err = selectManyWithAddFromList("select targets", addresses)
+		if err != nil {
+			return err
+		}
+		if len(addresses) == 0 {
+			return nil
+		}
+		if addresses[0] == "ALL" {
+			addresses = viper.GetStringSlice("address")
+		}
 		username := viper.GetString("username")
 		if username == "" {
 			if username, err = readUsername(); err != nil {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -55,6 +55,14 @@ var getCmd = &cobra.Command{
 				return err
 			}
 		}
+
+		if len(viper.GetStringSlice("get-path")) == 0 && viper.GetString("yang-file") != "" {
+			file = viper.GetString("yang-file")
+			err = pathCmd.RunE(pathCmd, []string{})
+			if err != nil {
+				return err
+			}
+		}
 		encodingVal, ok := gnmi.Encoding_value[strings.Replace(strings.ToUpper(viper.GetString("encoding")), "-", "_", -1)]
 		if !ok {
 			return fmt.Errorf("invalid encoding type '%s'", viper.GetString("encoding"))
@@ -223,7 +231,7 @@ var getCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(getCmd)
 
-	getCmd.Flags().StringSliceP("path", "", []string{"/"}, "get request paths")
+	getCmd.Flags().StringSliceP("path", "", []string{""}, "get request paths")
 	getCmd.Flags().StringP("prefix", "", "", "get request prefix")
 	getCmd.Flags().StringP("model", "", "", "get request model")
 	getCmd.Flags().StringP("type", "t", "ALL", "the type of data that is requested from the target. one of: ALL, CONFIG, STATE, OPERATIONAL")

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -44,19 +44,9 @@ var getCmd = &cobra.Command{
 			return err
 		}
 		if len(viper.GetStringSlice("get-path")) == 0 && viper.GetString("yang-file") != "" {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			paths, err := getPaths(ctx, viper.GetString("yang-file"), true)
+			result, err := selectPaths()
 			if err != nil {
 				return err
-			}
-			result, err := selectManyFromList("select paths", paths, 20)
-			if err != nil {
-				return err
-			}
-			if len(result) == 0 {
-				fmt.Println("Err: no paths selected")
-				return nil
 			}
 			viper.Set("get-path", result)
 		} else {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -39,10 +39,18 @@ var getCmd = &cobra.Command{
 		debug := viper.GetBool("debug")
 		var err error
 		addresses := viper.GetStringSlice("address")
+		addresses, err = selectManyWithAddFromList("select targets", addresses)
+		if err != nil {
+			return err
+		}
 		if len(addresses) == 0 {
 			fmt.Println("no grpc server address specified")
 			return nil
 		}
+		if addresses[0] == "ALL" {
+			addresses = viper.GetStringSlice("address")
+		}
+
 		if len(viper.GetStringSlice("get-path")) == 0 && viper.GetString("yang-file") != "" {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -236,7 +244,7 @@ var getCmd = &cobra.Command{
 					}
 					fmt.Println()
 				}
-			//fmt.Println()
+				//fmt.Println()
 				lock.Unlock()
 			}(addr)
 		}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -39,18 +39,10 @@ var getCmd = &cobra.Command{
 		debug := viper.GetBool("debug")
 		var err error
 		addresses := viper.GetStringSlice("address")
-		addresses, err = selectManyWithAddFromList("select targets", addresses)
+		addresses, err = selectTargets(addresses)
 		if err != nil {
 			return err
 		}
-		if len(addresses) == 0 {
-			fmt.Println("no grpc server address specified")
-			return nil
-		}
-		if addresses[0] == "ALL" {
-			addresses = viper.GetStringSlice("address")
-		}
-
 		if len(viper.GetStringSlice("get-path")) == 0 && viper.GetString("yang-file") != "" {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -49,10 +49,7 @@ var getCmd = &cobra.Command{
 				return err
 			}
 			viper.Set("get-path", result)
-		} else {
-			fmt.Println("Err: provide path(s) or a yang file to choose paths from")
-			return nil
-		}
+		} 
 		username := viper.GetString("username")
 		if username == "" {
 			if username, err = readUsername(); err != nil {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -43,13 +43,25 @@ var getCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
 		if len(viper.GetStringSlice("get-path")) == 0 && viper.GetString("yang-file") != "" {
 			result, err := selectPaths()
 			if err != nil {
 				return err
 			}
 			viper.Set("get-path", result)
-		} 
+		} else if len(viper.GetStringSlice("get-path")) == 0 {
+			pathPrefix, err := readFromPrompt("enter path prefix", viper.GetString("get-prefix"))
+			if err != nil {
+				return err
+			}
+			viper.Set("get-prefix", pathPrefix)
+			path, err := readFromPrompt("enter path", "")
+			if err != nil {
+				return err
+			}
+			viper.Set("get-path", path)
+		}
 		username := viper.GetString("username")
 		if username == "" {
 			if username, err = readUsername(); err != nil {
@@ -235,7 +247,7 @@ var getCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(getCmd)
 
-	getCmd.Flags().StringSliceP("path", "", []string{""}, "get request paths")
+	getCmd.Flags().StringSliceP("path", "", nil, "get request paths")
 	getCmd.Flags().StringP("prefix", "", "", "get request prefix")
 	getCmd.Flags().StringP("model", "", "", "get request model")
 	getCmd.Flags().StringP("type", "t", "ALL", "the type of data that is requested from the target. one of: ALL, CONFIG, STATE, OPERATIONAL")

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -44,7 +44,6 @@ var getCmd = &cobra.Command{
 			return nil
 		}
 		if len(viper.GetStringSlice("get-path")) == 0 && viper.GetString("yang-file") != "" {
-			file = viper.GetString("yang-file")
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			paths, err := getPaths(ctx, viper.GetString("yang-file"), true)
@@ -235,8 +234,9 @@ var getCmd = &cobra.Command{
 							fmt.Printf("%s%s: (%T) %s\n", printPrefix, gnmiPathToXPath(upd.Path), upd.Val.Value, value)
 						}
 					}
+					fmt.Println()
 				}
-				fmt.Println()
+			//fmt.Println()
 				lock.Unlock()
 			}(addr)
 		}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -77,26 +77,14 @@ func selectManyWithAddFromList(lsName string, items []string) ([]string, error) 
 	result := make([]string, 0)
 	choice := ""
 	var err error
-	nl := append([]string{".."}, items...)
+	nl := make([]string, len(items)+2)
+	copy(nl, []string{"ALL", ".."})
+	copy(nl[2:], items)
 	numSelected := 0
 	p := promptui.SelectWithAdd{
 		Label:    fmt.Sprintf("%s (selected:%d)", lsName, numSelected),
 		Items:    nl,
 		AddLabel: "Other:",
-		// Size:         pageSize,
-		// CursorPos:    pos,
-		// Stdout:       os.Stdout,
-		// HideSelected: true,
-		// Searcher: func(input string, index int) bool {
-		// 	return strings.Contains(nl[index], input)
-		// },
-		// Keys: &promptui.SelectKeys{
-		// 	Prev:     promptui.Key{Code: promptui.KeyPrev, Display: promptui.KeyPrevDisplay},
-		// 	Next:     promptui.Key{Code: promptui.KeyNext, Display: promptui.KeyNextDisplay},
-		// 	PageUp:   promptui.Key{Code: promptui.KeyBackward, Display: promptui.KeyBackwardDisplay},
-		// 	PageDown: promptui.Key{Code: promptui.KeyForward, Display: promptui.KeyForwardDisplay},
-		// 	Search:   promptui.Key{Code: ':', Display: ":"},
-		// },
 	}
 LOOP:
 	p.Label = fmt.Sprintf("%s (selected:%d)", lsName, numSelected)
@@ -106,6 +94,9 @@ LOOP:
 	}
 	if choice == ".." {
 		return result, nil
+	}
+	if choice == "ALL" {
+		return items, nil
 	}
 	for _, r := range result {
 		if r == choice {

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/manifoldco/promptui"
+	"github.com/spf13/viper"
 )
 
 func selectFromList(lsName string, items []string, initialPos, pageSize int) (int, string, error) {
@@ -106,4 +107,20 @@ LOOP:
 	numSelected++
 	result = append(result, choice)
 	goto LOOP
+}
+
+func selectTargets(addrs []string) ([]string, error) {
+	var err error
+	addrs, err = selectManyWithAddFromList("select targets", addrs)
+	if err != nil {
+		return nil, err
+	}
+	if len(addrs) == 0 {
+		fmt.Println("no grpc server address specified")
+		return nil, nil
+	}
+	if addrs[0] == "ALL" {
+		addrs = viper.GetStringSlice("address")
+	}
+	return addrs, nil
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -199,6 +199,9 @@ func readFromPrompt(label, defValue string) (string, error) {
 }
 
 func setPathKeys(p string) (string, error) {
+	if !strings.Contains(p, "*") {
+		return p, nil
+	}
 	gnmiPath, err := xpath.ToGNMIPath(p)
 	if err != nil {
 		return "", err

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -33,13 +34,14 @@ func selectManyFromList(lsName string, items []string, pageSize int) ([]string, 
 	var err error
 	pos := 0
 	nl := append([]string{".."}, items...)
+	numSelected := 0
 	p := promptui.Select{
-		Label:        lsName,
+		Label:        fmt.Sprintf("%s (selected:%d)", lsName, numSelected),
 		Items:        nl,
 		Size:         pageSize,
 		CursorPos:    pos,
 		Stdout:       os.Stdout,
-		HideSelected: false,
+		HideSelected: true,
 		Searcher: func(input string, index int) bool {
 			return strings.Contains(nl[index], input)
 		},
@@ -51,7 +53,8 @@ func selectManyFromList(lsName string, items []string, pageSize int) ([]string, 
 			Search:   promptui.Key{Code: ':', Display: ":"},
 		},
 	}
-CHOICE:
+LOOP:
+	p.Label = fmt.Sprintf("%s (selected:%d)", lsName, numSelected)
 	pos, choice, err = p.Run()
 	if err != nil {
 		return nil, err
@@ -62,9 +65,10 @@ CHOICE:
 	p.CursorPos = pos
 	for _, r := range result {
 		if r == choice {
-			goto CHOICE
+			goto LOOP
 		}
 	}
+	numSelected++
 	result = append(result, choice)
-	goto CHOICE
+	goto LOOP
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+)
+
+func selectFromList(lsName string, items []string, initialPos, pageSize int) (int, string, error) {
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+	p := promptui.Select{
+		Label:        lsName,
+		Items:        items,
+		Size:         pageSize,
+		CursorPos:    initialPos,
+		Stdout:       os.Stderr,
+		HideSelected: true,
+	}
+
+	pos, selected, err := p.Run()
+	if err != nil {
+		return 0, "", err
+	}
+	return pos, selected, nil
+}
+
+func selectManyFromList(lsName string, items []string, pageSize int) ([]string, error) {
+	result := make([]string, 0)
+	choice := ""
+	var err error
+	pos := 0
+	nl := append([]string{".."}, items...)
+	p := promptui.Select{
+		Label:        lsName,
+		Items:        nl,
+		Size:         pageSize,
+		CursorPos:    pos,
+		Stdout:       os.Stdout,
+		HideSelected: false,
+		Searcher: func(input string, index int) bool {
+			return strings.Contains(nl[index], input)
+		},
+		Keys: &promptui.SelectKeys{
+			Prev:     promptui.Key{Code: promptui.KeyPrev, Display: promptui.KeyPrevDisplay},
+			Next:     promptui.Key{Code: promptui.KeyNext, Display: promptui.KeyNextDisplay},
+			PageUp:   promptui.Key{Code: promptui.KeyBackward, Display: promptui.KeyBackwardDisplay},
+			PageDown: promptui.Key{Code: promptui.KeyForward, Display: promptui.KeyForwardDisplay},
+			Search:   promptui.Key{Code: ':', Display: ":"},
+		},
+	}
+CHOICE:
+	pos, choice, err = p.Run()
+	if err != nil {
+		return nil, err
+	}
+	if choice == ".." {
+		return result, nil
+	}
+	p.CursorPos = pos
+	for _, r := range result {
+		if r == choice {
+			goto CHOICE
+		}
+	}
+	result = append(result, choice)
+	goto CHOICE
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -72,3 +72,47 @@ LOOP:
 	result = append(result, choice)
 	goto LOOP
 }
+
+func selectManyWithAddFromList(lsName string, items []string) ([]string, error) {
+	result := make([]string, 0)
+	choice := ""
+	var err error
+	nl := append([]string{".."}, items...)
+	numSelected := 0
+	p := promptui.SelectWithAdd{
+		Label:    fmt.Sprintf("%s (selected:%d)", lsName, numSelected),
+		Items:    nl,
+		AddLabel: "Other:",
+		// Size:         pageSize,
+		// CursorPos:    pos,
+		// Stdout:       os.Stdout,
+		// HideSelected: true,
+		// Searcher: func(input string, index int) bool {
+		// 	return strings.Contains(nl[index], input)
+		// },
+		// Keys: &promptui.SelectKeys{
+		// 	Prev:     promptui.Key{Code: promptui.KeyPrev, Display: promptui.KeyPrevDisplay},
+		// 	Next:     promptui.Key{Code: promptui.KeyNext, Display: promptui.KeyNextDisplay},
+		// 	PageUp:   promptui.Key{Code: promptui.KeyBackward, Display: promptui.KeyBackwardDisplay},
+		// 	PageDown: promptui.Key{Code: promptui.KeyForward, Display: promptui.KeyForwardDisplay},
+		// 	Search:   promptui.Key{Code: ':', Display: ":"},
+		// },
+	}
+LOOP:
+	p.Label = fmt.Sprintf("%s (selected:%d)", lsName, numSelected)
+	_, choice, err = p.Run()
+	if err != nil {
+		return nil, err
+	}
+	if choice == ".." {
+		return result, nil
+	}
+	for _, r := range result {
+		if r == choice {
+			goto LOOP
+		}
+	}
+	numSelected++
+	result = append(result, choice)
+	goto LOOP
+}

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -53,7 +53,7 @@ var pathCmd = &cobra.Command{
 					Search:   promptui.Key{Code: ':', Display: ":"},
 				},
 			}
-			
+
 			for {
 				select {
 				case <-ctx.Done():
@@ -177,14 +177,15 @@ func getPaths(ctx context.Context, file string, search bool) ([]string, error) {
 	if !ok {
 		return nil, fmt.Errorf("module %s not found", module)
 	}
-
+	paths := make([]string, 0)
 	out := make(chan string, 0)
 	defer close(out)
-	paths := make([]string, 0)
+	nCtx, nCancel := context.WithCancel(ctx)
+	defer nCancel()
 	if search {
-		go gather(ctx, out, &paths)
+		go gather(nCtx, out, &paths)
 	} else {
-		go printer(ctx, out)
+		go printer(nCtx, out)
 	}
 	for _, c := range mod.Container {
 		addContainerToPath("", c, out)

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -42,7 +42,7 @@ var pathCmd = &cobra.Command{
 		if search {
 			p := promptui.Select{
 				Label:        "select path",
-				Items:        append(paths),
+				Items:        append([]string{".."}, paths...),
 				Size:         10,
 				Stdout:       os.Stdout,
 				HideSelected: true,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,7 @@ var rootCmd = &cobra.Command{
 			"path",
 			"capabilities",
 			"get",
-			//"set",
+			"set",
 			"subscribe"},
 			1, 6)
 		if err != nil {
@@ -61,6 +61,9 @@ var rootCmd = &cobra.Command{
 			return nil
 		}
 		switch cmdName {
+		case "path":
+			search = true
+			return pathCmd.RunE(pathCmd, nil)
 		case "capabilities":
 			return capabilitiesCmd.RunE(capabilitiesCmd, nil)
 		case "get":
@@ -113,6 +116,8 @@ func init() {
 	viper.BindPFlag("skip-verify", rootCmd.PersistentFlags().Lookup("skip-verify"))
 	viper.BindPFlag("no-prefix", rootCmd.PersistentFlags().Lookup("no-prefix"))
 	viper.BindPFlag("yang-file", rootCmd.PersistentFlags().Lookup("yang-file"))
+
+	rootCmd.SilenceUsage = true
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,26 +46,29 @@ var rootCmd = &cobra.Command{
 	Use:   "gnmiClient",
 	Short: "run gnmi rpcs from the terminal",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		_, cmdName, err := selectFromList("select cmd", []string{"..", "path", "capabilities", "get", "set", "subscribe"}, 1, 6)
+		_, cmdName, err := selectFromList("select cmd", []string{
+			"..",
+			"path",
+			"capabilities",
+			"get",
+			//"set",
+			"subscribe"},
+			1, 6)
 		if err != nil {
 			return err
 		}
 		if cmdName == ".." {
 			return nil
 		}
-		fmt.Println("you chose", cmdName)
-		paths, err := getPaths(ctx, viper.GetString("yang-file"), true)
-		if err != nil {
-			return err
-		}
-		result, err := selectManyFromList("select paths", paths, 20)
-		if err != nil {
-			return err
-		}
-		for _, p := range result {
-			fmt.Println("-", p)
+		switch cmdName {
+		case "capabilities":
+			return capabilitiesCmd.RunE(capabilitiesCmd, nil)
+		case "get":
+			return getCmd.RunE(getCmd, nil)
+		case "set":
+			//return setCmd.RunE(setCmd, nil)
+		case "subscribe":
+			return subscribeCmd.RunE(subscribeCmd, nil)
 		}
 		return nil
 	},
@@ -136,7 +139,7 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+		//fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}
 }
 func readUsername() (string, error) {
@@ -227,7 +230,6 @@ func loadCerts() ([]tls.Certificate, *x509.CertPool, error) {
 	}
 
 	return []tls.Certificate{certificate}, certPool, nil
-
 }
 
 func printer(ctx context.Context, c chan string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("timeout", "", "30s", "grpc timeout")
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "debug mode")
 	rootCmd.PersistentFlags().BoolP("skip-verify", "", false, "skip verify tls connection")
+	rootCmd.PersistentFlags().StringP("yang-file", "", "", "yang file")
 	//
 	viper.BindPFlag("address", rootCmd.PersistentFlags().Lookup("address"))
 	viper.BindPFlag("username", rootCmd.PersistentFlags().Lookup("username"))
@@ -90,6 +91,7 @@ func init() {
 	viper.BindPFlag("timeout", rootCmd.PersistentFlags().Lookup("timeout"))
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("skip-verify", rootCmd.PersistentFlags().Lookup("skip-verify"))
+	viper.BindPFlag("yang-file", rootCmd.PersistentFlags().Lookup("yang-file"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,7 +70,6 @@ var rootCmd = &cobra.Command{
 		case "get":
 			return getCmd.RunE(getCmd, nil)
 		case "set":
-
 			return setCmd.RunE(setCmd, nil)
 		case "subscribe":
 			return subscribeCmd.RunE(subscribeCmd, nil)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/gnxi/utils/xpath"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/spf13/cobra"
@@ -71,106 +70,7 @@ var rootCmd = &cobra.Command{
 		case "get":
 			return getCmd.RunE(getCmd, nil)
 		case "set":
-			addresses, err := selectTargets(viper.GetStringSlice("address"))
-			if err != nil {
-				return err
-			}
-			if len(addresses) == 0 {
-				return errors.New("no address provided")
-			}
-			viper.Set("address", addresses)
-			_, setType, err := selectFromList("select set type", []string{"update", "replace", "delete"}, 1, 4)
-			if err != nil {
-				return err
-			}
-			switch setType {
-			case "..":
-				return nil
-			case "update":
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				paths, err := getPaths(ctx, viper.GetString("yang-file"), true)
-				if err != nil {
-					return err
-				}
-				_, sp, err := selectFromList("select path", paths, 1, 15)
-				if err != nil {
-					return err
-				}
-				switch sp {
-				default:
-					sp, err = setPathKeys(sp)
-					if err != nil {
-						return err
-					}
-					fmt.Println("enter type and value (type:::value):")
-					v, err := readFromPrompt(sp)
-					if err != nil {
-						return err
-					}
-					viper.Set("update", strings.Join([]string{sp, v}, ":::"))
-				case "..":
-					return nil
-				}
-			case "replace":
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				paths, err := getPaths(ctx, viper.GetString("yang-file"), true)
-				if err != nil {
-					return err
-				}
-				_, sp, err := selectFromList("select path", paths, 1, 15)
-				if err != nil {
-					return err
-				}
-				switch sp {
-				default:
-					sp, err = setPathKeys(sp)
-					if err != nil {
-						return err
-					}
-					fmt.Println("enter type and value (type:::value):")
-					v, err := readFromPrompt(sp)
-					if err != nil {
-						return err
-					}
-					viper.Set("replace", strings.Join([]string{sp, v}, ":::"))
-				case "..":
-					return nil
-				}
-			case "delete":
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				paths, err := getPaths(ctx, viper.GetString("yang-file"), true)
-				if err != nil {
-					return err
-				}
-				_, sp, err := selectFromList("select path", paths, 1, 15)
-				if err != nil {
-					return err
-				}
-				switch sp {
-				default:
-					gnmiPath, err := xpath.ToGNMIPath(sp)
-					if err != nil {
-						return err
-					}
-					for _, pe := range gnmiPath.GetElem() {
-						if pe.GetKey() != nil {
-							for k := range pe.GetKey() {
-								v, err := readFromPrompt(fmt.Sprintf("enter value for %s[%s=*]", pe.GetName(), k))
-								if err != nil {
-									return err
-								}
-								pe.Key[k] = v
-							}
-						}
-					}
-					viper.Set("delete", gnmiPathToXPath(gnmiPath))
-				case "..":
-					return nil
-				}
-			}
+
 			return setCmd.RunE(setCmd, nil)
 		case "subscribe":
 			return subscribeCmd.RunE(subscribeCmd, nil)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,10 +45,30 @@ var cfgFile string
 var rootCmd = &cobra.Command{
 	Use:   "gnmiClient",
 	Short: "run gnmi rpcs from the terminal",
-
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	//	Run: func(cmd *cobra.Command, args []string) { },
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, cmdName, err := selectFromList("select cmd", []string{"..", "path", "capabilities", "get", "set", "subscribe"}, 1, 6)
+		if err != nil {
+			return err
+		}
+		if cmdName == ".." {
+			return nil
+		}
+		fmt.Println("you chose", cmdName)
+		paths, err := getPaths(ctx, viper.GetString("yang-file"), true)
+		if err != nil {
+			return err
+		}
+		result, err := selectManyFromList("select paths", paths, 20)
+		if err != nil {
+			return err
+		}
+		for _, p := range result {
+			fmt.Println("-", p)
+		}
+		return nil
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,6 +97,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("timeout", "", "30s", "grpc timeout")
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "debug mode")
 	rootCmd.PersistentFlags().BoolP("skip-verify", "", false, "skip verify tls connection")
+	rootCmd.PersistentFlags().BoolP("no-prefix", "", false, "do not add [ip:port] prefix to print output in case of multiple targets")
 	rootCmd.PersistentFlags().StringP("yang-file", "", "", "yang file")
 	//
 	viper.BindPFlag("address", rootCmd.PersistentFlags().Lookup("address"))
@@ -110,6 +111,7 @@ func init() {
 	viper.BindPFlag("timeout", rootCmd.PersistentFlags().Lookup("timeout"))
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("skip-verify", rootCmd.PersistentFlags().Lookup("skip-verify"))
+	viper.BindPFlag("no-prefix", rootCmd.PersistentFlags().Lookup("no-prefix"))
 	viper.BindPFlag("yang-file", rootCmd.PersistentFlags().Lookup("yang-file"))
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,6 +99,10 @@ var rootCmd = &cobra.Command{
 				}
 				switch sp {
 				default:
+					sp, err = setPathKeys(sp)
+					if err != nil {
+						return err
+					}
 					fmt.Println("enter type and value (type:::value):")
 					v, err := readFromPrompt(sp)
 					if err != nil {
@@ -121,6 +125,10 @@ var rootCmd = &cobra.Command{
 				}
 				switch sp {
 				default:
+					sp, err = setPathKeys(sp)
+					if err != nil {
+						return err
+					}
 					fmt.Println("enter type and value (type:::value):")
 					v, err := readFromPrompt(sp)
 					if err != nil {
@@ -328,7 +336,6 @@ func loadCerts() ([]tls.Certificate, *x509.CertPool, error) {
 
 	return []tls.Certificate{certificate}, certPool, nil
 }
-
 func printer(ctx context.Context, c chan string) {
 	for {
 		select {

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -44,10 +44,10 @@ var setCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		addresses := viper.GetStringSlice("address")
-		addresses, err = selectTargets(addresses)
-		if err != nil {
-			return err
-		}
+		// addresses, err = selectTargets(addresses)
+		// if err != nil {
+		// 	return err
+		// }
 		if len(addresses) > 1 {
 			fmt.Println("[warning] running set command on multiple targets")
 		}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -44,16 +44,9 @@ var setCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		addresses := viper.GetStringSlice("address")
-		addresses, err = selectManyWithAddFromList("select targets", addresses)
+		addresses, err = selectTargets(addresses)
 		if err != nil {
 			return err
-		}
-		if len(addresses) == 0 {
-			fmt.Println("no grpc server address specified")
-			return nil
-		}
-		if addresses[0] == "ALL" {
-			addresses = viper.GetStringSlice("address")
 		}
 		if len(addresses) > 1 {
 			fmt.Println("[warning] running set command on multiple targets")

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -44,8 +44,16 @@ var setCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		addresses := viper.GetStringSlice("address")
+		addresses, err = selectManyWithAddFromList("select targets", addresses)
+		if err != nil {
+			return err
+		}
 		if len(addresses) == 0 {
-			return errors.New("no address provided")
+			fmt.Println("no grpc server address specified")
+			return nil
+		}
+		if addresses[0] == "ALL" {
+			addresses = viper.GetStringSlice("address")
 		}
 		if len(addresses) > 1 {
 			fmt.Println("[warning] running set command on multiple targets")

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -229,7 +228,13 @@ func init() {
 func createSubscribeRequest() (*gnmi.SubscribeRequest, error) {
 	paths := viper.GetStringSlice("sub-path")
 	if len(paths) == 0 {
-		return nil, errors.New("no path provided")
+		var err error
+		paths, err = selectPaths()
+		if err != nil {
+			return nil, err
+		}
+		viper.Set("sub-path", paths)
+		paths = viper.GetStringSlice("sub-path")
 	}
 	gnmiPrefix, err := xpath.ToGNMIPath(viper.GetString("sub-prefix"))
 	if err != nil {

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -58,19 +58,9 @@ var subscribeCmd = &cobra.Command{
 			return err
 		}
 		if len(viper.GetStringSlice("sub-path")) == 0 && viper.GetString("yang-file") != "" {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			paths, err := getPaths(ctx, viper.GetString("yang-file"), true)
+			result, err := selectPaths()
 			if err != nil {
 				return err
-			}
-			result, err := selectManyFromList("select paths", paths, 20)
-			if err != nil {
-				return err
-			}
-			if len(result) == 0 {
-				fmt.Println("Err: no paths selected")
-				return nil
 			}
 			viper.Set("sub-path", result)
 		} else {

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -58,7 +58,6 @@ var subscribeCmd = &cobra.Command{
 			return nil
 		}
 		if len(viper.GetStringSlice("sub-path")) == 0 && viper.GetString("yang-file") != "" {
-			file = viper.GetString("yang-file")
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			paths, err := getPaths(ctx, viper.GetString("yang-file"), true)

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -53,9 +53,16 @@ var subscribeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		addresses := viper.GetStringSlice("address")
+		addresses, err = selectManyWithAddFromList("select targets", addresses)
+		if err != nil {
+			return err
+		}
 		if len(addresses) == 0 {
 			fmt.Println("no grpc server address specified")
 			return nil
+		}
+		if addresses[0] == "ALL" {
+			addresses = viper.GetStringSlice("address")
 		}
 		if len(viper.GetStringSlice("sub-path")) == 0 && viper.GetString("yang-file") != "" {
 			ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -53,16 +53,9 @@ var subscribeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		addresses := viper.GetStringSlice("address")
-		addresses, err = selectManyWithAddFromList("select targets", addresses)
+		addresses, err = selectTargets(addresses)
 		if err != nil {
 			return err
-		}
-		if len(addresses) == 0 {
-			fmt.Println("no grpc server address specified")
-			return nil
-		}
-		if addresses[0] == "ALL" {
-			addresses = viper.GetStringSlice("address")
 		}
 		if len(viper.GetStringSlice("sub-path")) == 0 && viper.GetString("yang-file") != "" {
 			ctx, cancel := context.WithCancel(context.Background())

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/openconfig/gnmi v0.0.0-20190823184014-89b2bf29312c
 	github.com/openconfig/goyang v0.0.0-20200309174518-a00bece872fc
 	github.com/spf13/cobra v0.0.6
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.6.2
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	google.golang.org/grpc v1.21.0


### PR DESCRIPTION
- Add the possibility to select paths from a yang file passed using a global flag --yang-file.
- The selected paths will then be used to send a get, set or subscribe rpc