### PR TITLE
added more human readable error msg for gRPC connection error

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -62,7 +63,11 @@ func getRequest(ctx context.Context, req *gnmi.GetRequest, target *target, wg *s
 	defer wg.Done()
 	conn, err := createGrpcConn(ctx, target.Address, nil)
 	if err != nil {
-		logger.Printf("connection to %s failed: %v", target.Address, err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			logger.Printf("gRPC connection to %s failed to establish in a configured %s interval", target.Address, viper.Get("timeout"))
+		} else {
+			logger.Printf("connection to %s failed: %v", target.Address, err)
+		}
 		return
 	}
 	client := gnmi.NewGNMIClient(conn)

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -99,7 +99,11 @@ func setRequest(ctx context.Context, req *gnmi.SetRequest, target *target, wg *s
 	defer wg.Done()
 	conn, err := createGrpcConn(ctx, target.Address, nil)
 	if err != nil {
-		logger.Printf("connection to %s failed: %v", target.Address, err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			logger.Printf("gRPC connection to %s failed to establish in a configured %s interval", target.Address, viper.Get("timeout"))
+		} else {
+			logger.Printf("connection to %s failed: %v", target.Address, err)
+		}
 		return
 	}
 	client := gnmi.NewGNMIClient(conn)

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -157,7 +157,11 @@ func subRequest(ctx context.Context,
 	defer wg.Done()
 	conn, err := createGrpcConn(ctx, target.Address, clientMetrics)
 	if err != nil {
-		logger.Printf("connection to %s failed: %v", target.Address, err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			logger.Printf("gRPC connection to %s failed to establish in a configured %s interval", target.Address, viper.Get("timeout"))
+		} else {
+			logger.Printf("connection to %s failed: %v", target.Address, err)
+		}
 		return
 	}
 


### PR DESCRIPTION
for the context "deadline exceeded" type of error provided a more understandable error message