### PR TITLE
Path origin

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/gnxi/utils/xpath"
 	"github.com/karimra/gnmic/collector"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/spf13/cobra"
@@ -167,7 +166,7 @@ func createGetRequest() (*gnmi.GetRequest, error) {
 	}
 	prefix := viper.GetString("get-prefix")
 	if prefix != "" {
-		gnmiPrefix, err := xpath.ToGNMIPath(prefix)
+		gnmiPrefix, err := parsePath(prefix)
 		if err != nil {
 			return nil, fmt.Errorf("prefix parse error: %v", err)
 		}
@@ -182,7 +181,7 @@ func createGetRequest() (*gnmi.GetRequest, error) {
 		req.Type = gnmi.GetRequest_DataType(dti)
 	}
 	for _, p := range paths {
-		gnmiPath, err := xpath.ToGNMIPath(strings.TrimSpace(p))
+		gnmiPath, err := parsePath(strings.TrimSpace(p))
 		if err != nil {
 			return nil, fmt.Errorf("path parse error: %v", err)
 		}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -166,7 +166,7 @@ func createGetRequest() (*gnmi.GetRequest, error) {
 	}
 	prefix := viper.GetString("get-prefix")
 	if prefix != "" {
-		gnmiPrefix, err := parsePath(prefix)
+		gnmiPrefix, err := collector.ParsePath(prefix)
 		if err != nil {
 			return nil, fmt.Errorf("prefix parse error: %v", err)
 		}
@@ -181,7 +181,7 @@ func createGetRequest() (*gnmi.GetRequest, error) {
 		req.Type = gnmi.GetRequest_DataType(dti)
 	}
 	for _, p := range paths {
-		gnmiPath, err := parsePath(strings.TrimSpace(p))
+		gnmiPath, err := collector.ParsePath(strings.TrimSpace(p))
 		if err != nil {
 			return nil, fmt.Errorf("path parse error: %v", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/google/gnxi/utils/xpath"
 	"github.com/karimra/gnmic/collector"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/mapstructure"
@@ -540,22 +539,4 @@ func createCollectorDialOpts() []grpc.DialOption {
 		opts = append(opts, grpc.WithNoProxy())
 	}
 	return opts
-}
-
-func parsePath(p string) (*gnmi.Path, error) {
-	var origin string
-	elems := strings.Split(p, "/")
-	if len(elems) > 0 {
-		f := strings.Split(elems[0], ":")
-		if len(f) > 1 {
-			origin = f[0]
-			elems[0] = strings.Join(f[1:], ":")
-		}
-	}
-	gnmiPath, err := xpath.ToGNMIPath(strings.Join(elems, "/"))
-	if err != nil {
-		return nil, err
-	}
-	gnmiPath.Origin = origin
-	return gnmiPath, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -223,20 +223,27 @@ func gnmiPathToXPath(p *gnmi.Path) string {
 	if p == nil {
 		return ""
 	}
-	pathElems := make([]string, 0, len(p.GetElem()))
-	for _, pe := range p.GetElem() {
-		elem := ""
-		if pe.GetName() != "" {
-			elem += pe.GetName()
-		}
-		if pe.GetKey() != nil {
-			for k, v := range pe.GetKey() {
-				elem += fmt.Sprintf("[%s=%s]", k, v)
-			}
-		}
-		pathElems = append(pathElems, elem)
+	sb := strings.Builder{}
+	if p.Origin != "" {
+		sb.WriteString(p.Origin)
+		sb.WriteString(":")
 	}
-	return strings.Join(pathElems, "/")
+	elems := p.GetElem()
+	numElems := len(elems)
+	for i, pe := range elems {
+		sb.WriteString(pe.GetName())
+		for k, v := range pe.GetKey() {
+			sb.WriteString("[")
+			sb.WriteString(k)
+			sb.WriteString("=")
+			sb.WriteString(v)
+			sb.WriteString("]")
+		}
+		if i+1 != numElems {
+			sb.WriteString("/")
+		}
+	}
+	return sb.String()
 }
 func loadCerts(tlscfg *tls.Config) error {
 	tlsCert := viper.GetString("tls-cert")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -230,6 +230,9 @@ func gnmiPathToXPath(p *gnmi.Path) string {
 	}
 	elems := p.GetElem()
 	numElems := len(elems)
+	if numElems > 0 {
+		sb.WriteString("/")
+	}
 	for i, pe := range elems {
 		sb.WriteString(pe.GetName())
 		for k, v := range pe.GetKey() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/gnxi/utils/xpath"
 	"github.com/karimra/gnmic/collector"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/mapstructure"
@@ -539,4 +540,22 @@ func createCollectorDialOpts() []grpc.DialOption {
 		opts = append(opts, grpc.WithNoProxy())
 	}
 	return opts
+}
+
+func parsePath(p string) (*gnmi.Path, error) {
+	var origin string
+	elems := strings.Split(p, "/")
+	if len(elems) > 0 {
+		f := strings.Split(elems[0], ":")
+		if len(f) > 1 {
+			origin = f[0]
+			elems[0] = strings.Join(f[1:], ":")
+		}
+	}
+	gnmiPath, err := xpath.ToGNMIPath(strings.Join(elems, "/"))
+	if err != nil {
+		return nil, err
+	}
+	gnmiPath.Origin = origin
+	return gnmiPath, nil
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/gnxi/utils/xpath"
 	"github.com/karimra/gnmic/collector"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/spf13/cobra"
@@ -264,7 +263,7 @@ func init() {
 
 func createSetRequest() (*gnmi.SetRequest, error) {
 	prefix := viper.GetString("set-prefix")
-	gnmiPrefix, err := xpath.ToGNMIPath(prefix)
+	gnmiPrefix, err := collector.ParsePath(prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +306,7 @@ func createSetRequest() (*gnmi.SetRequest, error) {
 		Update:  make([]*gnmi.Update, 0),
 	}
 	for _, p := range deletes {
-		gnmiPath, err := xpath.ToGNMIPath(strings.TrimSpace(p))
+		gnmiPath, err := collector.ParsePath(strings.TrimSpace(p))
 		if err != nil {
 			return nil, err
 		}
@@ -318,7 +317,7 @@ func createSetRequest() (*gnmi.SetRequest, error) {
 		if len(singleUpdate) < 3 {
 			return nil, fmt.Errorf("invalid inline update format: %s", updates)
 		}
-		gnmiPath, err := xpath.ToGNMIPath(strings.TrimSpace(singleUpdate[0]))
+		gnmiPath, err := collector.ParsePath(strings.TrimSpace(singleUpdate[0]))
 		if err != nil {
 			return nil, err
 		}
@@ -337,7 +336,7 @@ func createSetRequest() (*gnmi.SetRequest, error) {
 		if len(singleReplace) < 3 {
 			return nil, fmt.Errorf("invalid inline replace format: %s", updates)
 		}
-		gnmiPath, err := xpath.ToGNMIPath(strings.TrimSpace(singleReplace[0]))
+		gnmiPath, err := collector.ParsePath(strings.TrimSpace(singleReplace[0]))
 		if err != nil {
 			return nil, err
 		}
@@ -352,7 +351,7 @@ func createSetRequest() (*gnmi.SetRequest, error) {
 		})
 	}
 	for i, p := range updatePaths {
-		gnmiPath, err := xpath.ToGNMIPath(strings.TrimSpace(p))
+		gnmiPath, err := collector.ParsePath(strings.TrimSpace(p))
 		if err != nil {
 			return nil, err
 		}
@@ -379,7 +378,7 @@ func createSetRequest() (*gnmi.SetRequest, error) {
 		})
 	}
 	for i, p := range replacePaths {
-		gnmiPath, err := xpath.ToGNMIPath(strings.TrimSpace(p))
+		gnmiPath, err := collector.ParsePath(strings.TrimSpace(p))
 		if err != nil {
 			return nil, err
 		}

--- a/collector/helpers.go
+++ b/collector/helpers.go
@@ -1,0 +1,28 @@
+package collector
+
+import (
+	"strings"
+
+	"github.com/google/gnxi/utils/xpath"
+	"github.com/openconfig/gnmi/proto/gnmi"
+)
+
+// ParsePath creates a gnmi.Path out of a p string, check if the first element is prefixed by an origin,
+// removes it from the xpath and adds it to the returned gnmiPath
+func ParsePath(p string) (*gnmi.Path, error) {
+	var origin string
+	elems := strings.Split(p, "/")
+	if len(elems) > 0 {
+		f := strings.Split(elems[0], ":")
+		if len(f) > 1 {
+			origin = f[0]
+			elems[0] = strings.Join(f[1:], ":")
+		}
+	}
+	gnmiPath, err := xpath.ToGNMIPath(strings.Join(elems, "/"))
+	if err != nil {
+		return nil, err
+	}
+	gnmiPath.Origin = origin
+	return gnmiPath, nil
+}

--- a/collector/subscription.go
+++ b/collector/subscription.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/gnxi/utils/xpath"
 	"github.com/openconfig/gnmi/proto/gnmi"
 )
 
@@ -62,7 +61,7 @@ func (sc *SubscriptionConfig) CreateSubscribeRequest() (*gnmi.SubscribeRequest, 
 	if err := sc.setDefaults(); err != nil {
 		return nil, err
 	}
-	gnmiPrefix, err := xpath.ToGNMIPath(sc.Prefix)
+	gnmiPrefix, err := ParsePath(sc.Prefix)
 	if err != nil {
 		return nil, fmt.Errorf("prefix parse error: %v", err)
 	}
@@ -78,7 +77,7 @@ func (sc *SubscriptionConfig) CreateSubscribeRequest() (*gnmi.SubscribeRequest, 
 
 	subscriptions := make([]*gnmi.Subscription, len(sc.Paths))
 	for i, p := range sc.Paths {
-		gnmiPath, err := xpath.ToGNMIPath(strings.TrimSpace(p))
+		gnmiPath, err := ParsePath(strings.TrimSpace(p))
 		if err != nil {
 			return nil, fmt.Errorf("path '%s' parse error: %v", p, err)
 		}


### PR DESCRIPTION
- Support origin in gnmi prefix and gnmi path.
- path (prefix) format: origin:path
- supported in both command line and config file