### PR TITLE
aligned sample-interval to 0s

### DIFF
--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -317,6 +317,8 @@ func getOutputs() (map[string][]outputs.Output, error) {
 func getSubscriptions() (map[string]*collector.SubscriptionConfig, error) {
 	subscriptions := make(map[string]*collector.SubscriptionConfig)
 	paths := viper.GetStringSlice("subscribe-path")
+	hi := viper.GetDuration("subscribe-heartbeat-interval")
+	si := viper.GetDuration("subscribe-sample-interval")
 	if len(paths) > 0 {
 		sub := new(collector.SubscriptionConfig)
 		sub.Name = "default"
@@ -326,8 +328,8 @@ func getSubscriptions() (map[string]*collector.SubscriptionConfig, error) {
 		sub.Encoding = viper.GetString("encoding")
 		sub.Qos = viper.GetUint32("qos")
 		sub.StreamMode = viper.GetString("subscribe-stream-mode")
-		sub.HeartbeatInterval = viper.GetDuration("subscribe-heartbeat-interval")
-		sub.SampleInterval = viper.GetDuration("subscribe-sample-interval")
+		sub.HeartbeatInterval = &hi
+		sub.SampleInterval = &si
 		sub.SuppressRedundant = viper.GetBool("subscribe-suppress-redundant")
 		sub.UpdatesOnly = viper.GetBool("subscribe-updates-only")
 		sub.Models = viper.GetStringSlice("models")
@@ -353,8 +355,11 @@ func getSubscriptions() (map[string]*collector.SubscriptionConfig, error) {
 			return nil, err
 		}
 		sub.Name = sn
-		if sub.SampleInterval == 0 { // inherit global "subscribe-sample-interval" option if its not set (or set to 0) in a file
-			sub.SampleInterval = viper.GetDuration("subscribe-sample-interval")
+		if sub.SampleInterval == nil { // inherit global "subscribe-sample-interval" option if its not set
+			sub.SampleInterval = &si
+		}
+		if sub.HeartbeatInterval == nil { // inherit global "subscribe-heartbeat-interval" option if its not set
+			sub.HeartbeatInterval = &hi
 		}
 		subscriptions[sn] = sub
 	}

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -195,8 +195,8 @@ func init() {
 	subscribeCmd.Flags().BoolP("updates-only", "", false, "only updates to current state should be sent")
 	subscribeCmd.Flags().StringP("mode", "", "stream", "one of: once, stream, poll")
 	subscribeCmd.Flags().StringP("stream-mode", "", "target-defined", "one of: on-change, sample, target-defined")
-	subscribeCmd.Flags().StringP("sample-interval", "i", "10s",
-		"sample interval as a decimal number and a suffix unit, such as \"10s\" or \"1m30s\", minimum is 1s")
+	subscribeCmd.Flags().StringP("sample-interval", "i", "0s",
+		"sample interval as a decimal number and a suffix unit, such as \"10s\" or \"1m30s\"")
 	subscribeCmd.Flags().BoolP("suppress-redundant", "", false, "suppress redundant update if the subscribed value didn't not change")
 	subscribeCmd.Flags().StringP("heartbeat-interval", "", "0s", "heartbeat interval in case suppress-redundant is enabled")
 	subscribeCmd.Flags().StringSliceP("model", "", []string{""}, "subscribe request used model(s)")
@@ -353,6 +353,9 @@ func getSubscriptions() (map[string]*collector.SubscriptionConfig, error) {
 			return nil, err
 		}
 		sub.Name = sn
+		if sub.SampleInterval == 0 { // inherit global "subscribe-sample-interval" option if its not set (or set to 0) in a file
+			sub.SampleInterval = viper.GetDuration("subscribe-sample-interval")
+		}
 		subscriptions[sn] = sub
 	}
 	return subscriptions, nil

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -195,10 +195,10 @@ func init() {
 	subscribeCmd.Flags().BoolP("updates-only", "", false, "only updates to current state should be sent")
 	subscribeCmd.Flags().StringP("mode", "", "stream", "one of: once, stream, poll")
 	subscribeCmd.Flags().StringP("stream-mode", "", "target-defined", "one of: on-change, sample, target-defined")
-	subscribeCmd.Flags().StringP("sample-interval", "i", "0s",
+	subscribeCmd.Flags().DurationP("sample-interval", "i", 0,
 		"sample interval as a decimal number and a suffix unit, such as \"10s\" or \"1m30s\"")
 	subscribeCmd.Flags().BoolP("suppress-redundant", "", false, "suppress redundant update if the subscribed value didn't not change")
-	subscribeCmd.Flags().StringP("heartbeat-interval", "", "0s", "heartbeat interval in case suppress-redundant is enabled")
+	subscribeCmd.Flags().DurationP("heartbeat-interval", "", 0, "heartbeat interval in case suppress-redundant is enabled")
 	subscribeCmd.Flags().StringSliceP("model", "", []string{""}, "subscribe request used model(s)")
 	subscribeCmd.Flags().Bool("quiet", false, "suppress stdout printing")
 	//

--- a/collector/subscription.go
+++ b/collector/subscription.go
@@ -12,18 +12,18 @@ import (
 
 // SubscriptionConfig //
 type SubscriptionConfig struct {
-	Name              string        `mapstructure:"name,omitempty"`
-	Models            []string      `mapstructure:"models,omitempty"`
-	Prefix            string        `mapstructure:"prefix,omitempty"`
-	Paths             []string      `mapstructure:"paths,omitempty"`
-	Mode              string        `mapstructure:"mode,omitempty"`
-	StreamMode        string        `mapstructure:"stream-mode,omitempty"`
-	Encoding          string        `mapstructure:"encoding,omitempty"`
-	Qos               uint32        `mapstructure:"qos,omitempty"`
-	SampleInterval    time.Duration `mapstructure:"sample-interval,omitempty"`
-	HeartbeatInterval time.Duration `mapstructure:"heartbeat-interval,omitempty"`
-	SuppressRedundant bool          `mapstructure:"suppress-redundant,omitempty"`
-	UpdatesOnly       bool          `mapstructure:"updates-only,omitempty"`
+	Name              string         `mapstructure:"name,omitempty"`
+	Models            []string       `mapstructure:"models,omitempty"`
+	Prefix            string         `mapstructure:"prefix,omitempty"`
+	Paths             []string       `mapstructure:"paths,omitempty"`
+	Mode              string         `mapstructure:"mode,omitempty"`
+	StreamMode        string         `mapstructure:"stream-mode,omitempty"`
+	Encoding          string         `mapstructure:"encoding,omitempty"`
+	Qos               uint32         `mapstructure:"qos,omitempty"`
+	SampleInterval    *time.Duration `mapstructure:"sample-interval,omitempty"`
+	HeartbeatInterval *time.Duration `mapstructure:"heartbeat-interval,omitempty"`
+	SuppressRedundant bool           `mapstructure:"suppress-redundant,omitempty"`
+	UpdatesOnly       bool           `mapstructure:"updates-only,omitempty"`
 }
 
 // String //

--- a/collector/subscription.go
+++ b/collector/subscription.go
@@ -42,7 +42,7 @@ func (sc *SubscriptionConfig) setDefaults() error {
 	if sc.Mode == "" {
 		sc.Mode = "STREAM"
 	}
-	if sc.Mode == "STREAM" && sc.StreamMode == "" {
+	if strings.ToUpper(sc.Mode) == "STREAM" && sc.StreamMode == "" {
 		sc.StreamMode = "TARGET_DEFINED"
 	}
 	if sc.Encoding == "" {
@@ -50,9 +50,6 @@ func (sc *SubscriptionConfig) setDefaults() error {
 	}
 	if sc.Qos == 0 {
 		sc.Qos = 20
-	}
-	if sc.StreamMode == "SAMPLE" && sc.SampleInterval == 0 {
-		sc.SampleInterval = 10 * time.Second
 	}
 	return nil
 }


### PR DESCRIPTION
this PR assumes the following logic:

* default sample-interval is 0s (iso 10s as before)
* a global `subscribe-sample-interval` key inside `gnmic.yml` file acts as an enforcer of sample-interval for all subscriptions for which sample interval either not set or set to 0

If we would want to inherit `subscribe-sample-interval` only when the file based subscription definition doesn't specify sample-interval, we would need to change to pointer for `SampleInterval` field

closes #88 