### PR TITLE
Rework Output interface

### DIFF
--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -76,9 +76,9 @@ func reqCapability(ctx context.Context, target *collector.Target, wg *sync.WaitG
 	defer m.Unlock()
 	err = printMsg(target.Config.Name, "Capabilities Response", response)
 	if err != nil {
-		logger.Printf("error marshaling capabilities response msg: %v", err)
+		logger.Printf("error marshaling capabilities response from %s: %v", target.Config.Name, err)
 		if !viper.GetBool("log") {
-			fmt.Printf("error marshaling set capabilities msg: %v\n", err)
+			fmt.Printf("error marshaling capabilities response from %s: %v\n", target.Config.Name, err)
 		}
 	}
 

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/karimra/gnmic/collector"
@@ -74,7 +75,8 @@ func reqCapability(ctx context.Context, target *collector.Target, wg *sync.WaitG
 	}
 	m.Lock()
 	defer m.Unlock()
-	err = printMsg(target.Config.Name, "Capabilities Response", response)
+	fmt.Fprint(os.Stderr, "Capabilities Response:\n")
+	err = printMsg(target.Config.Name, response)
 	if err != nil {
 		logger.Printf("error marshaling capabilities response from %s: %v", target.Config.Name, err)
 		if !viper.GetBool("log") {

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -24,6 +25,7 @@ import (
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
 	"github.com/spf13/viper"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"github.com/spf13/cobra"
@@ -85,21 +87,58 @@ func printCapResponse(r *gnmi.CapabilityResponse, address string) {
 	if len(addresses) > 1 && !viper.GetBool("no-prefix") {
 		printPrefix = fmt.Sprintf("[%s] ", address)
 	}
-	if viper.GetString("format") == "prototext" {
+	switch viper.GetString("format") {
+	case "protojson":
+		b, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(r)
+		if err != nil {
+			logger.Printf("error marshaling protojson msg: %v", err)
+			if !viper.GetBool("log") {
+				fmt.Printf("error marshaling protojson msg: %v\n", err)
+			}
+			return
+		}
+		fmt.Printf("%s\n", indent(printPrefix, string(b)))
+		return
+	case "prototext":
 		fmt.Printf("%s\n", indent(printPrefix, prototext.Format(r)))
 		return
-	}
-	fmt.Printf("%sgNMI version: %s\n", printPrefix, r.GNMIVersion)
-	if viper.GetBool("version") {
-		return
-	}
-	fmt.Printf("%ssupported models:\n", printPrefix)
-	for _, sm := range r.SupportedModels {
-		fmt.Printf("%s  - %s, %s, %s\n", printPrefix, sm.GetName(), sm.GetOrganization(), sm.GetVersion())
-	}
-	fmt.Printf("%ssupported encodings:\n", printPrefix)
-	for _, se := range r.SupportedEncodings {
-		fmt.Printf("%s  - %s\n", printPrefix, se.String())
+	case "json":
+		capRspMsg := capResponse{}
+
+		capRspMsg.Version = r.GetGNMIVersion()
+		for _, sm := range r.SupportedModels {
+			capRspMsg.SupportedModels = append(capRspMsg.SupportedModels,
+				supportedModels{
+					Name:         sm.GetName(),
+					Organization: sm.GetOrganization(),
+					Version:      sm.GetVersion(),
+				})
+		}
+		for _, se := range r.SupportedEncodings {
+			capRspMsg.Encodings = append(capRspMsg.Encodings, se.String())
+		}
+		b, err := json.MarshalIndent(capRspMsg, printPrefix, "  ")
+		if err != nil {
+			logger.Printf("failed to marshal capabilities response: %v", err)
+			if !viper.GetBool("log") {
+				fmt.Printf("failed to marshal capabilities response: %v", err)
+				return
+			}
+		}
+		fmt.Println(string(b))
+	default:
+		fmt.Printf("%sgNMI version: %s\n", printPrefix, r.GNMIVersion)
+		if viper.GetBool("version") {
+			return
+		}
+		fmt.Printf("%ssupported models:\n", printPrefix)
+		for _, sm := range r.SupportedModels {
+			fmt.Printf("%s  - %s, %s, %s\n", printPrefix, sm.GetName(), sm.GetOrganization(), sm.GetVersion())
+		}
+		fmt.Printf("%ssupported encodings:\n", printPrefix)
+		for _, se := range r.SupportedEncodings {
+			fmt.Printf("%s  - %s\n", printPrefix, se.String())
+		}
 	}
 	fmt.Println()
 }
@@ -108,4 +147,15 @@ func init() {
 	rootCmd.AddCommand(capabilitiesCmd)
 	capabilitiesCmd.Flags().BoolVarP(&printVersion, "version", "", false, "show gnmi version only")
 	viper.BindPFlag("capabilities-version", capabilitiesCmd.LocalFlags().Lookup("version"))
+}
+
+type capResponse struct {
+	Version         string            `json:"version,omitempty"`
+	SupportedModels []supportedModels `json:"supported-models,omitempty"`
+	Encodings       []string          `json:"encodings,omitempty"`
+}
+type supportedModels struct {
+	Name         string `json:"name,omitempty"`
+	Organization string `json:"organization,omitempty"`
+	Version      string `json:"version,omitempty"`
 }

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -98,6 +98,7 @@ func printCapResponse(r *gnmi.CapabilityResponse, address string) {
 			if !viper.GetBool("log") {
 				fmt.Printf("error marshaling msg: %v\n", err)
 			}
+			return
 		}
 		fmt.Printf("%s\n", indent(printPrefix, string(b)))
 		return

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -85,7 +85,7 @@ func printCapResponse(r *gnmi.CapabilityResponse, address string) {
 	if len(addresses) > 1 && !viper.GetBool("no-prefix") {
 		printPrefix = fmt.Sprintf("[%s] ", address)
 	}
-	if viper.GetString("format") == "textproto" {
+	if viper.GetString("format") == "prototext" {
 		fmt.Printf("%s\n", indent(printPrefix, prototext.Format(r)))
 		return
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -102,7 +102,7 @@ func printGetResponse(address string, response *gnmi.GetResponse) {
 	if numTargets() > 1 && !viper.GetBool("no-prefix") {
 		printPrefix = fmt.Sprintf("[%s] ", address)
 	}
-	if viper.GetString("format") == "textproto" {
+	if viper.GetString("format") == "prototext" {
 		fmt.Printf("%s\n", indent(printPrefix, prototext.Format(response)))
 		return
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
 )
 
@@ -102,39 +103,55 @@ func printGetResponse(address string, response *gnmi.GetResponse) {
 	if numTargets() > 1 && !viper.GetBool("no-prefix") {
 		printPrefix = fmt.Sprintf("[%s] ", address)
 	}
-	if viper.GetString("format") == "prototext" {
-		fmt.Printf("%s\n", indent(printPrefix, prototext.Format(response)))
-		return
-	}
-	for _, notif := range response.Notification {
-		msg := new(msg)
-		msg.Source = address
-		msg.Timestamp = notif.Timestamp
-		t := time.Unix(0, notif.Timestamp)
-		msg.Time = &t
-		msg.Prefix = gnmiPathToXPath(notif.Prefix)
-		for i, upd := range notif.Update {
-			pathElems := make([]string, 0, len(upd.Path.Elem))
-			for _, pElem := range upd.Path.Elem {
-				pathElems = append(pathElems, pElem.GetName())
-			}
-			value, err := getValue(upd.Val)
-			if err != nil {
-				logger.Println(err)
-			}
-			msg.Updates = append(msg.Updates,
-				&update{
-					Path:   gnmiPathToXPath(upd.Path),
-					Values: make(map[string]interface{}),
-				})
-			msg.Updates[i].Values[strings.Join(pathElems, "/")] = value
-		}
-		dMsg, err := json.MarshalIndent(msg, printPrefix, "  ")
+	switch viper.GetString("format") {
+	case "protojson":
+		b, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(response)
 		if err != nil {
-			logger.Printf("error marshling json msg:%v", err)
+			logger.Printf("error marshaling protojson msg: %v", err)
+			if !viper.GetBool("log") {
+				fmt.Printf("error marshaling protojson msg: %v\n", err)
+			}
 			return
 		}
-		fmt.Printf("%s%s\n", printPrefix, string(dMsg))
+		fmt.Printf("%s\n", indent(printPrefix, string(b)))
+		return
+	case "prototext":
+		fmt.Printf("%s\n", indent(printPrefix, prototext.Format(response)))
+		return
+	case "json":
+		for _, notif := range response.Notification {
+			msg := new(msg)
+			msg.Source = address
+			msg.Timestamp = notif.Timestamp
+			t := time.Unix(0, notif.Timestamp)
+			msg.Time = &t
+			msg.Prefix = gnmiPathToXPath(notif.Prefix)
+			for i, upd := range notif.Update {
+				pathElems := make([]string, 0, len(upd.Path.Elem))
+				for _, pElem := range upd.Path.Elem {
+					pathElems = append(pathElems, pElem.GetName())
+				}
+				value, err := getValue(upd.Val)
+				if err != nil {
+					logger.Println(err)
+				}
+				msg.Updates = append(msg.Updates,
+					&update{
+						Path:   gnmiPathToXPath(upd.Path),
+						Values: make(map[string]interface{}),
+					})
+				msg.Updates[i].Values[strings.Join(pathElems, "/")] = value
+			}
+			dMsg, err := json.MarshalIndent(msg, printPrefix, "  ")
+			if err != nil {
+				logger.Printf("error marshling json msg:%v", err)
+				return
+			}
+			fmt.Printf("%s%s\n", printPrefix, string(dMsg))
+		}
+	case "event":
+		fmt.Println("event format is not implemented for get command")
+		return
 	}
 	fmt.Println()
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -83,7 +84,8 @@ func getRequest(ctx context.Context, req *gnmi.GetRequest, target *collector.Tar
 	}
 	if viper.GetBool("get-print-request") {
 		lock.Lock()
-		err := printMsg(target.Config.Name, "Get Request", req)
+		fmt.Fprint(os.Stderr, "Get Request:\n")
+		err := printMsg(target.Config.Name, req)
 		if err != nil {
 			logger.Printf("error marshaling get request msg: %v", err)
 			if !viper.GetBool("log") {
@@ -101,7 +103,8 @@ func getRequest(ctx context.Context, req *gnmi.GetRequest, target *collector.Tar
 	}
 	lock.Lock()
 	defer lock.Unlock()
-	err = printMsg(target.Config.Name, "Get Response", response)
+	fmt.Fprint(os.Stderr, "Get Response:\n")
+	err = printMsg(target.Config.Name, response)
 	if err != nil {
 		logger.Printf("error marshaling get response from %s: %v\n", target.Config.Name, err)
 		if !viper.GetBool("log") {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -103,9 +103,9 @@ func getRequest(ctx context.Context, req *gnmi.GetRequest, target *collector.Tar
 	defer lock.Unlock()
 	err = printMsg(target.Config.Name, "Get Response", response)
 	if err != nil {
-		logger.Printf("error marshaling get response msg: %v", err)
+		logger.Printf("error marshaling get response from %s: %v\n", target.Config.Name, err)
 		if !viper.GetBool("log") {
-			fmt.Printf("error marshaling get response msg: %v\n", err)
+			fmt.Printf("error marshaling get response from %s: %v\n", target.Config.Name, err)
 		}
 	}
 	//printGetResponse(target.Config.Name, response)

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -15,14 +15,12 @@
 package cmd
 
 import (
-	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
-	"sync"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/karimra/gnmic/outputs"
@@ -166,7 +164,7 @@ func (s *dialoutTelemetryServer) Publish(stream nokiasros.DialoutTelemetry_Publi
 	} else {
 		logger.Println("could not find system-name in http2 headers")
 	}
-	lock := new(sync.Mutex)
+	//lock := new(sync.Mutex)
 	for {
 		subResp, err := stream.Recv()
 		if err != nil {
@@ -181,25 +179,25 @@ func (s *dialoutTelemetryServer) Publish(stream nokiasros.DialoutTelemetry_Publi
 		}
 		switch resp := subResp.Response.(type) {
 		case *gnmi.SubscribeResponse_Update:
-			b, err := formatSubscribeResponse(meta, subResp)
-			if err != nil {
-				logger.Printf("failed to format subscribe response: %v", err)
-				continue
-			}
+			// b, err := formatSubscribeResponse(meta, subResp)
+			// if err != nil {
+			// 	logger.Printf("failed to format subscribe response: %v", err)
+			// 	continue
+			// }
 			for _, outputs := range s.Outputs {
 				for _, o := range outputs {
-					go o.Write(b, outMeta)
+					go o.Write(subResp, outMeta)
 				}
 			}
-			buff := new(bytes.Buffer)
-			err = json.Indent(buff, b, "", "  ")
-			if err != nil {
-				logger.Printf("failed to indent msg: err=%v, msg=%s", err, string(b))
-				continue
-			}
-			lock.Lock()
-			fmt.Println(buff.String())
-			lock.Unlock()
+			// buff := new(bytes.Buffer)
+			// err = json.Indent(buff, b, "", "  ")
+			// if err != nil {
+			// 	logger.Printf("failed to indent msg: err=%v, msg=%s", err, string(b))
+			// 	continue
+			// }
+			// lock.Lock()
+			// fmt.Println(buff.String())
+			// lock.Unlock()
 		case *gnmi.SubscribeResponse_SyncResponse:
 			logger.Printf("received sync response=%+v from %s\n", resp.SyncResponse, meta["source"])
 		}

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -114,7 +114,7 @@ var listenCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(listenCmd)
-
+	listenCmd.SilenceUsage = true
 	listenCmd.Flags().Uint32P("max-concurrent-streams", "", 256, "max concurrent streams gnmic can receive per transport")
 
 	viper.BindPFlag("listen-max-concurrent-streams", listenCmd.LocalFlags().Lookup("max-concurrent-streams"))

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -113,6 +113,7 @@ var pathCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(pathCmd)
+	pathCmd.SilenceUsage = true
 	pathCmd.Flags().StringVarP(&file, "file", "", "", "yang file")
 	pathCmd.Flags().StringVarP(&pathType, "path-type", "", "xpath", "path type xpath or gnmi")
 	pathCmd.Flags().StringVarP(&module, "module", "m", "nokia-state", "module name")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,7 +119,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("skip-verify", "", false, "skip verify tls connection")
 	rootCmd.PersistentFlags().BoolP("no-prefix", "", false, "do not add [ip:port] prefix to print output in case of multiple targets")
 	rootCmd.PersistentFlags().BoolP("proxy-from-env", "", false, "use proxy from environment")
-	rootCmd.PersistentFlags().StringP("format", "", "json", "output format, one of: [prototext, json]")
+	rootCmd.PersistentFlags().StringP("format", "", "", "output format, one of: [protojson, prototext, json, event]")
 	rootCmd.PersistentFlags().StringP("log-file", "", "", "log file path")
 	rootCmd.PersistentFlags().BoolP("log", "", false, "show log messages in stderr")
 	rootCmd.PersistentFlags().IntP("max-msg-size", "", msgSize, "max grpc msg size")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,6 +124,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("log", "", false, "show log messages in stderr")
 	rootCmd.PersistentFlags().IntP("max-msg-size", "", msgSize, "max grpc msg size")
 	rootCmd.PersistentFlags().StringP("prometheus-address", "", "0.0.0.0:9094", "prometheus server address")
+	rootCmd.PersistentFlags().BoolP("print-request", "", false, "print request as well as the response(s)")
 	//
 	viper.BindPFlag("address", rootCmd.PersistentFlags().Lookup("address"))
 	viper.BindPFlag("username", rootCmd.PersistentFlags().Lookup("username"))
@@ -144,6 +145,7 @@ func init() {
 	viper.BindPFlag("log", rootCmd.PersistentFlags().Lookup("log"))
 	viper.BindPFlag("max-msg-size", rootCmd.PersistentFlags().Lookup("max-msg-size"))
 	viper.BindPFlag("prometheus-address", rootCmd.PersistentFlags().Lookup("prometheus-address"))
+	viper.BindPFlag("print-request", rootCmd.PersistentFlags().Lookup("print-request"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,7 +119,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("skip-verify", "", false, "skip verify tls connection")
 	rootCmd.PersistentFlags().BoolP("no-prefix", "", false, "do not add [ip:port] prefix to print output in case of multiple targets")
 	rootCmd.PersistentFlags().BoolP("proxy-from-env", "", false, "use proxy from environment")
-	rootCmd.PersistentFlags().StringP("format", "", "json", "output format, one of: [textproto, json]")
+	rootCmd.PersistentFlags().StringP("format", "", "json", "output format, one of: [prototext, json]")
 	rootCmd.PersistentFlags().StringP("log-file", "", "", "log file path")
 	rootCmd.PersistentFlags().BoolP("log", "", false, "show log messages in stderr")
 	rootCmd.PersistentFlags().IntP("max-msg-size", "", msgSize, "max grpc msg size")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -486,7 +486,7 @@ func createCollectorDialOpts() []grpc.DialOption {
 	return opts
 }
 
-func printMsg(address, annotation string, msg proto.Message) error {
+func printMsg(address string, msg proto.Message) error {
 	printPrefix := ""
 	if numTargets() > 1 && !viper.GetBool("no-prefix") {
 		printPrefix = fmt.Sprintf("[%s] ", address)
@@ -537,8 +537,6 @@ func printMsg(address, annotation string, msg proto.Message) error {
 		return err
 	}
 	sb := strings.Builder{}
-	sb.WriteString(annotation)
-	sb.WriteString(":\n")
 	sb.Write(b)
 	fmt.Printf("%s\n", indent(printPrefix, sb.String()))
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -495,35 +495,7 @@ func printMsg(address string, msg proto.Message) error {
 	switch msg := msg.ProtoReflect().Interface().(type) {
 	case *gnmi.CapabilityResponse:
 		if len(viper.GetString("format")) == 0 {
-			sb := strings.Builder{}
-			sb.WriteString(printPrefix)
-			sb.WriteString("gNMI version: ")
-			sb.WriteString(msg.GNMIVersion)
-			sb.WriteString("\n")
-			if viper.GetBool("version") {
-				return nil
-			}
-			sb.WriteString(printPrefix)
-			sb.WriteString("supported models:\n")
-			for _, sm := range msg.SupportedModels {
-				sb.WriteString(printPrefix)
-				sb.WriteString("  - ")
-				sb.WriteString(sm.GetName())
-				sb.WriteString(", ")
-				sb.WriteString(sm.GetOrganization())
-				sb.WriteString(", ")
-				sb.WriteString(sm.GetVersion())
-				sb.WriteString("\n")
-			}
-			sb.WriteString(printPrefix)
-			sb.WriteString("supported encodings:\n")
-			for _, se := range msg.SupportedEncodings {
-				sb.WriteString(printPrefix)
-				sb.WriteString("  - ")
-				sb.WriteString(se.String())
-				sb.WriteString("\n")
-			}
-			fmt.Printf("%s\n", indent(printPrefix, sb.String()))
+			printCapResponse(printPrefix, msg)
 			return nil
 		}
 	}
@@ -540,4 +512,36 @@ func printMsg(address string, msg proto.Message) error {
 	sb.Write(b)
 	fmt.Printf("%s\n", indent(printPrefix, sb.String()))
 	return nil
+}
+
+func printCapResponse(printPrefix string, msg *gnmi.CapabilityResponse) {
+	sb := strings.Builder{}
+	sb.WriteString(printPrefix)
+	sb.WriteString("gNMI version: ")
+	sb.WriteString(msg.GNMIVersion)
+	sb.WriteString("\n")
+	if viper.GetBool("version") {
+		return
+	}
+	sb.WriteString(printPrefix)
+	sb.WriteString("supported models:\n")
+	for _, sm := range msg.SupportedModels {
+		sb.WriteString(printPrefix)
+		sb.WriteString("  - ")
+		sb.WriteString(sm.GetName())
+		sb.WriteString(", ")
+		sb.WriteString(sm.GetOrganization())
+		sb.WriteString(", ")
+		sb.WriteString(sm.GetVersion())
+		sb.WriteString("\n")
+	}
+	sb.WriteString(printPrefix)
+	sb.WriteString("supported encodings:\n")
+	for _, se := range msg.SupportedEncodings {
+		sb.WriteString(printPrefix)
+		sb.WriteString("  - ")
+		sb.WriteString(se.String())
+		sb.WriteString("\n")
+	}
+	fmt.Printf("%s\n", indent(printPrefix, sb.String()))
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -99,9 +99,9 @@ func setRequest(ctx context.Context, req *gnmi.SetRequest, target *collector.Tar
 	defer lock.Unlock()
 	err = printMsg(target.Config.Name, "Set Response", response)
 	if err != nil {
-		logger.Printf("error marshaling set response msg: %v", err)
+		logger.Printf("error marshaling set response from %s: %v\n", target.Config.Name, err)
 		if !viper.GetBool("log") {
-			fmt.Printf("error marshaling set response msg: %v\n", err)
+			fmt.Printf("error marshaling set response from %s: %v\n", target.Config.Name, err)
 		}
 	}
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -166,7 +166,7 @@ func convert(i interface{}) interface{} {
 	return i
 }
 func printSetRequest(printPrefix string, request *gnmi.SetRequest) {
-	if viper.GetString("format") == "textproto" {
+	if viper.GetString("format") == "prototext" {
 		fmt.Printf("%s\n", indent("  ", prototext.Format(request)))
 		return
 	}
@@ -204,7 +204,7 @@ func printSetRequest(printPrefix string, request *gnmi.SetRequest) {
 	fmt.Println(string(b))
 }
 func printSetResponse(printPrefix, address string, response *gnmi.SetResponse) {
-	if viper.GetString("format") == "textproto" {
+	if viper.GetString("format") == "prototext" {
 		fmt.Printf("%s\n", indent(printPrefix, prototext.Format(response)))
 		return
 	}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -81,7 +82,8 @@ func setRequest(ctx context.Context, req *gnmi.SetRequest, target *collector.Tar
 		req.Prefix, req.Delete, req.Replace, req.Update, req.Extension, target.Config.Address)
 	if viper.GetBool("set-print-request") {
 		lock.Lock()
-		err := printMsg(target.Config.Name, "Set Request", req)
+		fmt.Fprint(os.Stderr, "Set Request:\n")
+		err := printMsg(target.Config.Name, req)
 		if err != nil {
 			logger.Printf("error marshaling set request msg: %v", err)
 			if !viper.GetBool("log") {
@@ -97,7 +99,8 @@ func setRequest(ctx context.Context, req *gnmi.SetRequest, target *collector.Tar
 	}
 	lock.Lock()
 	defer lock.Unlock()
-	err = printMsg(target.Config.Name, "Set Response", response)
+	fmt.Fprint(os.Stderr, "Set Response:\n")
+	err = printMsg(target.Config.Name, response)
 	if err != nil {
 		logger.Printf("error marshaling set response from %s: %v\n", target.Config.Name, err)
 		if !viper.GetBool("log") {

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -181,6 +181,7 @@ var subscribeCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(subscribeCmd)
+	subscribeCmd.SilenceUsage = true
 	subscribeCmd.Flags().StringP("prefix", "", "", "subscribe request prefix")
 	subscribeCmd.Flags().StringSliceP("path", "", []string{""}, "subscribe request paths")
 	//subscribeCmd.MarkFlagRequired("path")

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -275,6 +275,7 @@ func getOutputs() (map[string][]outputs.Output, error) {
 		stdoutConfig := map[string]interface{}{
 			"type":      "file",
 			"file-type": "stdout",
+			"format":    viper.GetString("format"),
 		}
 		stdoutFile := make([]interface{}, 1)
 		stdoutFile[0] = stdoutConfig

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -213,7 +213,7 @@ func init() {
 func formatSubscribeResponse(meta map[string]interface{}, subResp *gnmi.SubscribeResponse) ([]byte, error) {
 	switch resp := subResp.Response.(type) {
 	case *gnmi.SubscribeResponse_Update:
-		if viper.GetString("format") == "textproto" {
+		if viper.GetString("format") == "prototext" {
 			return []byte(prototext.Format(subResp)), nil
 		}
 		msg := new(msg)

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -123,6 +123,10 @@ var subscribeCmd = &cobra.Command{
 			}
 			waitChan := make(chan struct{}, 1)
 			waitChan <- struct{}{}
+			mo := &collector.MarshalOptions{
+				Multiline: true,
+				Indent:    "  ",
+				Format:    viper.GetString("format")}
 			go func() {
 				for {
 					select {
@@ -157,7 +161,7 @@ var subscribeCmd = &cobra.Command{
 							waitChan <- struct{}{}
 							continue
 						}
-						b, err := collector.FormatMsg(nil, response, true, "  ")
+						b, err := mo.Marshal(response, nil)
 						if err != nil {
 							fmt.Printf("target '%s', subscription '%s': poll response formatting error:%v\n", name, subName, err)
 							fmt.Println(string(b))
@@ -229,10 +233,10 @@ func getOutputs() (map[string][]outputs.Output, error) {
 				case map[string]interface{}:
 					if outType, ok := ou["type"]; ok {
 						if initalizer, ok := outputs.Outputs[outType.(string)]; ok {
-							 format, ok := ou["format"]
-							 if !ok || (ok && format == "") {
+							format, ok := ou["format"]
+							if !ok || (ok && format == "") {
 								ou["format"] = viper.GetString("format")
-							} 
+							}
 							o := initalizer()
 							err := o.Init(ou, logger)
 							if err != nil {

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/karimra/gnmic/collector"
 	"github.com/karimra/gnmic/outputs"
@@ -33,22 +32,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-type msg struct {
-	Meta             map[string]interface{} `json:"meta,omitempty"`
-	Source           string                 `json:"source,omitempty"`
-	SystemName       string                 `json:"system-name,omitempty"`
-	SubscriptionName string                 `json:"subscription-name,omitempty"`
-	Timestamp        int64                  `json:"timestamp,omitempty"`
-	Time             *time.Time             `json:"time,omitempty"`
-	Prefix           string                 `json:"prefix,omitempty"`
-	Updates          []*update              `json:"updates,omitempty"`
-	Deletes          []string               `json:"deletes,omitempty"`
-}
-type update struct {
-	Path   string
-	Values map[string]interface{} `json:"values,omitempty"`
-}
 
 // subscribeCmd represents the subscribe command
 var subscribeCmd = &cobra.Command{

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -217,9 +217,7 @@ func getOutputs() (map[string][]outputs.Output, error) {
 			"file-type": "stdout",
 			"format":    viper.GetString("format"),
 		}
-		stdoutFile := make([]interface{}, 1)
-		stdoutFile[0] = stdoutConfig
-		outDef["stdout"] = stdoutFile
+		outDef["stdout"] = []interface{}{stdoutConfig}
 	}
 	outputDestinations := make(map[string][]outputs.Output)
 	for name, d := range outDef {
@@ -231,6 +229,10 @@ func getOutputs() (map[string][]outputs.Output, error) {
 				case map[string]interface{}:
 					if outType, ok := ou["type"]; ok {
 						if initalizer, ok := outputs.Outputs[outType.(string)]; ok {
+							 format, ok := ou["format"]
+							 if !ok || (ok && format == "") {
+								ou["format"] = viper.GetString("format")
+							} 
 							o := initalizer()
 							err := o.Init(ou, logger)
 							if err != nil {

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -160,20 +159,14 @@ var subscribeCmd = &cobra.Command{
 							waitChan <- struct{}{}
 							continue
 						}
-						b, err := collector.FormatMsg(nil, response)
+						b, err := collector.FormatMsg(nil, response, true, "  ")
 						if err != nil {
 							fmt.Printf("target '%s', subscription '%s': poll response formatting error:%v\n", name, subName, err)
-							continue
-						}
-						dst := new(bytes.Buffer)
-						err = json.Indent(dst, b, "", "  ")
-						if err != nil {
-							fmt.Printf("failed to indent poll response from '%s': %v\n", name, err)
 							fmt.Println(string(b))
 							waitChan <- struct{}{}
 							continue
 						}
-						fmt.Println(dst.String())
+						fmt.Println(string(b))
 						waitChan <- struct{}{}
 					case <-ctx.Done():
 						return

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -160,7 +160,7 @@ var subscribeCmd = &cobra.Command{
 							waitChan <- struct{}{}
 							continue
 						}
-						b, err := coll.FormatMsg(nil, response)
+						b, err := collector.FormatMsg(nil, response)
 						if err != nil {
 							fmt.Printf("target '%s', subscription '%s': poll response formatting error:%v\n", name, subName, err)
 							continue

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,9 +15,11 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -33,11 +35,29 @@ var versionCmd = &cobra.Command{
 	Short: "show gnmic version",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("version : %s\n", version)
-		fmt.Printf(" commit : %s\n", commit)
-		fmt.Printf("   date : %s\n", date)
-		fmt.Printf(" gitURL : %s\n", gitURL)
-		fmt.Printf("   docs : https://gnmic.kmrd.dev\n")
+		if viper.GetString("format") != "json" {
+			fmt.Printf("version : %s\n", version)
+			fmt.Printf(" commit : %s\n", commit)
+			fmt.Printf("   date : %s\n", date)
+			fmt.Printf(" gitURL : %s\n", gitURL)
+			fmt.Printf("   docs : https://gnmic.kmrd.dev\n")
+			return
+		}
+		b, err := json.Marshal(map[string]string{
+			"version": version,
+			"commit":  commit,
+			"date":    date,
+			"gitURL":  gitURL,
+			"docs":    "https://gnmic.kmrd.dev",
+		}) // need indent? use jq
+		if err != nil {
+			logger.Printf("failed: %v", err)
+			if !viper.GetBool("log") {
+				fmt.Printf("failed: %v\n", err)
+			}
+			return
+		}
+		fmt.Println(string(b))
 	},
 }
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -199,6 +199,8 @@ func (c *Collector) Start() {
 						return
 					}
 					c.Logger.Printf("target '%s' error: %v", t.Config.Name, err)
+				case <-c.ctx.Done():
+					c.cancelFn()
 				}
 			}
 		}(t)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -344,11 +344,15 @@ func Marshal(msg proto.Message, format string, meta map[string]string, multiline
 				if err != nil {
 					return nil, fmt.Errorf("failed converting response to events: %v", err)
 				}
-				b, err = json.Marshal(events)
+				if multiline {
+					b, err = json.MarshalIndent(events, "", indent)
+				} else {
+					b, err = json.Marshal(events)
+				}
 				if err != nil {
-
 					return nil, fmt.Errorf("failed marshaling events: %v", err)
 				}
+
 			case *gnmi.SubscribeResponse_SyncResponse:
 				//c.Logger.Printf("received subscribe syncResponse with %v", meta)
 			case *gnmi.SubscribeResponse_Error:

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -256,11 +256,10 @@ func FormatMsg(meta map[string]string, rsp proto.Message, multiline bool, indent
 			for _, del := range rsp.Update.Delete {
 				msg.Deletes = append(msg.Deletes, gnmiPathToXPath(del))
 			}
-			data, err := json.Marshal(msg)
-			if err != nil {
-				return nil, err
+			if multiline {
+				return json.MarshalIndent(msg, "", indent)
 			}
-			return data, nil
+			return json.Marshal(msg)
 		}
 	}
 	return nil, nil

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -212,7 +212,7 @@ func (c *Collector) Start() {
 }
 
 // FormatMsg formats the gnmi.SubscribeResponse and returns a []byte and an error
-func FormatMsg(meta map[string]string, rsp proto.Message) ([]byte, error) {
+func FormatMsg(meta map[string]string, rsp proto.Message, multiline bool, indent string) ([]byte, error) {
 	if rsp == nil {
 		return nil, nil
 	}
@@ -323,7 +323,7 @@ func Marshal(msg proto.Message, format string, meta map[string]string, multiline
 	var err error
 	switch format {
 	case "json":
-		b, err = FormatMsg(meta, msg)
+		b, err = FormatMsg(meta, msg, multiline, indent)
 	case "proto":
 		b, err = proto.Marshal(msg)
 	case "protojson":

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -216,9 +216,6 @@ func FormatMsg(meta map[string]string, rsp proto.Message, multiline bool, indent
 	if rsp == nil {
 		return nil, nil
 	}
-	// if c.Config.Format == "textproto" {
-	// 	return []byte(prototext.Format(rsp)), nil
-	// }
 	switch rsp := rsp.ProtoReflect().Interface().(type) {
 	case *gnmi.SubscribeResponse:
 		switch rsp := rsp.Response.(type) {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -180,18 +180,10 @@ func (c *Collector) Start() {
 					if c.Config.Debug {
 						c.Logger.Printf("received gNMI Subscribe Response: %+v", rsp)
 					}
-					m := make(map[string]interface{})
-					m["subscription-name"] = rsp.SubscriptionName
-					m["source"] = t.Config.Name
-					b, err := c.FormatMsg(m, rsp.Response)
-					if err != nil {
-						c.Logger.Printf("failed formatting msg from target '%s': %v", t.Config.Name, err)
-						continue
-					}
 					if c.subscriptionMode(rsp.SubscriptionName) == "ONCE" {
-						t.Export(b, outputs.Meta{"source": t.Config.Name, "format": c.Config.Format, "subscription-name": rsp.SubscriptionName})
+						t.Export(rsp.Response, outputs.Meta{"source": t.Config.Name, "format": c.Config.Format, "subscription-name": rsp.SubscriptionName})
 					} else {
-						go t.Export(b, outputs.Meta{"source": t.Config.Name, "format": c.Config.Format, "subscription-name": rsp.SubscriptionName})
+						go t.Export(rsp.Response, outputs.Meta{"source": t.Config.Name, "format": c.Config.Format, "subscription-name": rsp.SubscriptionName})
 					}
 					if remainingOnceSubscriptions > 0 {
 						if c.subscriptionMode(rsp.SubscriptionName) == "ONCE" {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -327,7 +327,7 @@ func Marshal(msg proto.Message, format string, meta map[string]string, multiline
 	case "proto":
 		b, err = proto.Marshal(msg)
 	case "protojson":
-		b, err = protojson.Marshal(msg)
+		b, err = protojson.MarshalOptions{Multiline: multiline, Indent: indent}.Marshal(msg)
 	case "prototext":
 		b, err = prototext.MarshalOptions{Multiline: multiline, Indent: indent}.Marshal(msg)
 	case "event":
@@ -363,9 +363,7 @@ func Marshal(msg proto.Message, format string, meta map[string]string, multiline
 		}
 	}
 	if err != nil {
-
 		return nil, fmt.Errorf("failed marshaling event: %v", err)
 	}
-
 	return b, nil
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -349,13 +349,6 @@ func Marshal(msg proto.Message, format string, meta map[string]string, multiline
 				if err != nil {
 					return nil, fmt.Errorf("failed marshaling events: %v", err)
 				}
-
-			case *gnmi.SubscribeResponse_SyncResponse:
-				//c.Logger.Printf("received subscribe syncResponse with %v", meta)
-			case *gnmi.SubscribeResponse_Error:
-				gnmiErr := msg.GetError()
-				return nil, fmt.Errorf("received subscribe response error with %v, code=%d, message=%v, data=%v ",
-					meta, gnmiErr.Code, gnmiErr.Message, gnmiErr.Data)
 			}
 		}
 	}

--- a/collector/event.go
+++ b/collector/event.go
@@ -26,17 +26,7 @@ func ResponseToEventMsgs(name string, rsp *gnmi.SubscribeResponse, meta map[stri
 	evs := make([]*EventMsg, 0)
 	switch rsp := rsp.Response.(type) {
 	case *gnmi.SubscribeResponse_Update:
-		tags := make(map[string]string)
 		namePrefix, prefixTags := TagsFromGNMIPath(rsp.Update.Prefix)
-		for k, v := range prefixTags {
-			if vv, ok := tags[k]; ok {
-				if v != vv {
-					tags[namePrefix+":::"+k] = v
-				}
-				continue
-			}
-			tags[k] = v
-		}
 		for _, upd := range rsp.Update.Update {
 			e := &EventMsg{
 				Tags:   make(map[string]string),
@@ -44,7 +34,7 @@ func ResponseToEventMsgs(name string, rsp *gnmi.SubscribeResponse, meta map[stri
 			}
 			e.Timestamp = rsp.Update.Timestamp
 			e.Name = name
-			for k, v := range tags {
+			for k, v := range prefixTags {
 				e.Tags[k] = v
 			}
 			pathName, pTags := TagsFromGNMIPath(upd.Path)
@@ -81,7 +71,9 @@ func ResponseToEventMsgs(name string, rsp *gnmi.SubscribeResponse, meta map[stri
 			}
 			e.Timestamp = rsp.Update.Timestamp
 			e.Name = name
-			e.Tags = tags
+			for k, v := range prefixTags {
+				e.Tags[k] = v
+			}
 			for k, v := range meta {
 				if k == "format" {
 					continue

--- a/collector/event.go
+++ b/collector/event.go
@@ -115,6 +115,9 @@ func TagsFromGNMIPath(p *gnmi.Path) (string, map[string]string) {
 			}
 		}
 	}
+	if p.GetTarget() != "" {
+		tags["target"] = p.GetTarget()
+	}
 	return sb.String(), tags
 }
 

--- a/collector/event.go
+++ b/collector/event.go
@@ -167,7 +167,6 @@ func getValueFlat(prefix string, updValue *gnmi.TypedValue) (map[string]interfac
 	case *gnmi.TypedValue_JsonVal:
 		jsondata = updValue.GetJsonVal()
 	}
-	//	fmt.Println(string(jsondata))
 	if len(jsondata) != 0 {
 		var value interface{}
 		err := json.Unmarshal(jsondata, &value)

--- a/collector/event.go
+++ b/collector/event.go
@@ -1,0 +1,183 @@
+package collector
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/jeremywohl/flatten"
+	"github.com/openconfig/gnmi/proto/gnmi"
+)
+
+// EventMsg //
+type EventMsg struct {
+	Name      string                 `json:"name,omitempty"` // measurement name
+	Timestamp int64                  `json:"timestamp,omitempty"`
+	Tags      map[string]string      `json:"tags,omitempty"`
+	Values    map[string]interface{} `json:"values,omitempty"`
+	Deletes   []string               `json:"deletes,omitempty"`
+}
+
+// ResponseToEventMsgs //
+func ResponseToEventMsgs(name string, rsp *gnmi.SubscribeResponse, meta map[string]string) ([]*EventMsg, error) {
+	if rsp == nil {
+		return nil, nil
+	}
+	evs := make([]*EventMsg, 0)
+	switch rsp := rsp.Response.(type) {
+	case *gnmi.SubscribeResponse_Update:
+		tags := make(map[string]string)
+		namePrefix, prefixTags := TagsFromGNMIPath(rsp.Update.Prefix)
+		for k, v := range prefixTags {
+			if _, ok := tags[k]; ok {
+				tags[strings.Join([]string{namePrefix, k}, "/")] = v
+				continue
+			}
+			tags[k] = v
+		}
+		e := &EventMsg{
+			Tags:   make(map[string]string),
+			Values: make(map[string]interface{}),
+		}
+		e.Timestamp = rsp.Update.Timestamp
+		e.Name = name
+		e.Tags = tags
+		e.Values = make(map[string]interface{})
+		for _, upd := range rsp.Update.Update {
+			pathName, pTags := TagsFromGNMIPath(upd.Path)
+			pathName = strings.TrimRight(namePrefix, "/") + "/" + strings.TrimLeft(pathName, "/")
+			for k, v := range pTags {
+				if _, ok := e.Tags[k]; ok {
+					e.Tags[strings.Join([]string{pathName, k}, "/")] = v
+					continue
+				}
+				e.Tags[k] = v
+			}
+			vs, err := parseUpdate(pathName, upd)
+			if err != nil {
+				return nil, err
+			}
+			for k, v := range vs {
+				e.Values[k] = v
+			}
+		}
+		for k, v := range meta {
+			if k == "format" {
+				continue
+			}
+			if _, ok := e.Tags[k]; ok {
+				e.Tags["meta:"+k] = v
+				continue
+			}
+			e.Tags[k] = v
+		}
+		evs = append(evs, e)
+		if len(rsp.Update.Delete) > 0 {
+			e := &EventMsg{
+				Deletes: make([]string, 0, len(rsp.Update.Delete)),
+			}
+			e.Timestamp = rsp.Update.Timestamp
+			e.Name = name
+			e.Tags = tags
+			for k, v := range meta {
+				if k == "format" {
+					continue
+				}
+				if _, ok := e.Tags[k]; ok {
+					e.Tags["meta:"+k] = v
+					continue
+				}
+				e.Tags[k] = v
+			}
+			for _, del := range rsp.Update.Delete {
+				e.Deletes = append(e.Deletes, gnmiPathToXPath(del))
+			}
+			evs = append(evs, e)
+		}
+	}
+	return evs, nil
+}
+
+// TagsFromGNMIPath //
+func TagsFromGNMIPath(p *gnmi.Path) (string, map[string]string) {
+	tags := make(map[string]string)
+	sb := strings.Builder{}
+	if p.Origin != "" {
+		sb.WriteString(p.Origin)
+		sb.Write([]byte(":"))
+	}
+	for _, e := range p.Elem {
+		if e.Name != "" {
+			sb.Write([]byte("/"))
+			sb.WriteString(e.Name)
+		}
+		if e.Key != nil {
+			for k, v := range e.Key {
+				tags[k] = v
+			}
+		}
+	}
+	return sb.String(), tags
+}
+
+// parseUpdate //
+func parseUpdate(prefix string, upd *gnmi.Update) (map[string]interface{}, error) {
+	val, err := getValueFlat(prefix, upd.GetVal())
+	if err != nil {
+		return nil, err
+	}
+	return val, nil
+}
+
+func getValueFlat(prefix string, updValue *gnmi.TypedValue) (map[string]interface{}, error) {
+	if updValue == nil {
+		return nil, nil
+	}
+	var jsondata []byte
+	values := make(map[string]interface{})
+	switch updValue.Value.(type) {
+	case *gnmi.TypedValue_AsciiVal:
+		values[prefix] = updValue.GetAsciiVal()
+	case *gnmi.TypedValue_BoolVal:
+		values[prefix] = updValue.GetBoolVal()
+	case *gnmi.TypedValue_BytesVal:
+		values[prefix] = updValue.GetBytesVal()
+	case *gnmi.TypedValue_DecimalVal:
+		values[prefix] = updValue.GetDecimalVal()
+	case *gnmi.TypedValue_FloatVal:
+		values[prefix] = updValue.GetFloatVal()
+	case *gnmi.TypedValue_IntVal:
+		values[prefix] = updValue.GetIntVal()
+	case *gnmi.TypedValue_StringVal:
+		values[prefix] = updValue.GetStringVal()
+	case *gnmi.TypedValue_UintVal:
+		values[prefix] = updValue.GetUintVal()
+	case *gnmi.TypedValue_LeaflistVal:
+		values[prefix] = updValue.GetLeaflistVal()
+	case *gnmi.TypedValue_ProtoBytes:
+		values[prefix] = updValue.GetProtoBytes()
+	case *gnmi.TypedValue_AnyVal:
+		values[prefix] = updValue.GetAnyVal()
+	case *gnmi.TypedValue_JsonIetfVal:
+		jsondata = updValue.GetJsonIetfVal()
+	case *gnmi.TypedValue_JsonVal:
+		jsondata = updValue.GetJsonVal()
+	}
+	//	fmt.Println(string(jsondata))
+	if len(jsondata) != 0 {
+		var value interface{}
+		err := json.Unmarshal(jsondata, &value)
+		if err != nil {
+			return nil, err
+		}
+		switch value := value.(type) {
+		case map[string]interface{}:
+			values, err = flatten.Flatten(value, prefix, flatten.PathStyle)
+		default:
+			values[prefix] = value
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	return values, nil
+}

--- a/collector/event.go
+++ b/collector/event.go
@@ -53,7 +53,7 @@ func ResponseToEventMsgs(name string, rsp *gnmi.SubscribeResponse, meta map[stri
 				}
 				e.Tags[k] = v
 			}
-			vs, err := parseUpdate(pathName, upd)
+			vs, err := getValueFlat(pathName, upd.GetVal())
 			if err != nil {
 				return nil, err
 			}
@@ -122,15 +122,6 @@ func TagsFromGNMIPath(p *gnmi.Path) (string, map[string]string) {
 		}
 	}
 	return sb.String(), tags
-}
-
-// parseUpdate //
-func parseUpdate(prefix string, upd *gnmi.Update) (map[string]interface{}, error) {
-	val, err := getValueFlat(prefix, upd.GetVal())
-	if err != nil {
-		return nil, err
-	}
-	return val, nil
 }
 
 func getValueFlat(prefix string, updValue *gnmi.TypedValue) (map[string]interface{}, error) {

--- a/collector/event.go
+++ b/collector/event.go
@@ -44,7 +44,9 @@ func ResponseToEventMsgs(name string, rsp *gnmi.SubscribeResponse, meta map[stri
 			}
 			e.Timestamp = rsp.Update.Timestamp
 			e.Name = name
-			e.Tags = tags
+			for k, v := range tags {
+				e.Tags[k] = v
+			}
 			pathName, pTags := TagsFromGNMIPath(upd.Path)
 			pathName = strings.TrimRight(namePrefix, "/") + "/" + strings.TrimLeft(pathName, "/")
 			for k, v := range pTags {
@@ -167,6 +169,7 @@ func getValueFlat(prefix string, updValue *gnmi.TypedValue) (map[string]interfac
 		switch value := value.(type) {
 		case map[string]interface{}:
 			f := flattener.NewFlattener()
+			f.SetPrefix(prefix)
 			values, err = f.Flatten(value)
 		default:
 			values[prefix] = value

--- a/collector/event_test.go
+++ b/collector/event_test.go
@@ -1,0 +1,82 @@
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/openconfig/gnmi/proto/gnmi"
+)
+
+var jsonData = `
+{
+    "admin-state": "enable",
+    "ipv4": {
+        "primary": {
+            "address": "1.1.1.1",
+            "prefix-length": 32
+        }
+    }
+}
+`
+var value = &gnmi.TypedValue{
+	Value: &gnmi.TypedValue_JsonVal{
+		JsonVal: []byte(jsonData),
+	},
+}
+
+func TestGetValueFlat(t *testing.T) {
+	v, err := getValueFlat("/configure/router[router-name=Base]/interface[interface-name=int1]", value)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Printf("%+v\n", v)
+	t.Logf("%v", v)
+}
+
+func TestResponseToEventMsgs(t *testing.T) {
+	rsp := &gnmi.SubscribeResponse{
+		Response: &gnmi.SubscribeResponse_Update{
+			Update: &gnmi.Notification{
+				Timestamp: time.Now().UnixNano(),
+				Prefix: &gnmi.Path{
+					Elem: []*gnmi.PathElem{
+						{Name: "a"},
+					},
+				},
+				Update: []*gnmi.Update{
+					{
+						Path: &gnmi.Path{
+							Elem: []*gnmi.PathElem{
+								{Name: "b",
+									Key: map[string]string{
+										"k1": "v1",
+									},
+								},
+								{Name: "c",
+									Key: map[string]string{
+										"k2": "v2",
+									}},
+							},
+						},
+						Val: &gnmi.TypedValue{
+							Value: &gnmi.TypedValue_StringVal{
+								StringVal: "value",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	evs, err := ResponseToEventMsgs("subname", rsp, map[string]string{"k1": "v0"})
+	if err != nil {
+		t.Error(err)
+	}
+	spew.Dump(evs)
+	t.Logf("%v", evs)
+	b, _ := json.MarshalIndent(evs, "", "  ")
+	fmt.Println(string(b))
+}

--- a/collector/event_test.go
+++ b/collector/event_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/openconfig/gnmi/proto/gnmi"
 )
 
@@ -75,7 +74,6 @@ func TestResponseToEventMsgs(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	spew.Dump(evs)
 	t.Logf("%v", evs)
 	b, _ := json.MarshalIndent(evs, "", "  ")
 	fmt.Println(string(b))

--- a/collector/formats.go
+++ b/collector/formats.go
@@ -15,7 +15,6 @@ import (
 type MarshalOptions struct {
 	Multiline bool // could get rid of this and deduct it from len(Indent)
 	Indent    string
-	Prefix    string
 	Format    string
 }
 
@@ -122,7 +121,7 @@ func (o *MarshalOptions) formatsubscribeRequest(m *gnmi.SubscribeRequest) ([]byt
 		}
 	}
 	if o.Multiline {
-		return json.MarshalIndent(msg, o.Prefix, o.Indent)
+		return json.MarshalIndent(msg, "", o.Indent)
 	}
 	return json.Marshal(msg)
 }
@@ -169,7 +168,7 @@ func (o *MarshalOptions) formatSubscribeResponse(m *gnmi.SubscribeResponse, meta
 			msg.Deletes = append(msg.Deletes, gnmiPathToXPath(del))
 		}
 		if o.Multiline {
-			return json.MarshalIndent(msg, o.Prefix, o.Indent)
+			return json.MarshalIndent(msg, "", o.Indent)
 		}
 		return json.Marshal(msg)
 	}
@@ -184,7 +183,7 @@ func (o *MarshalOptions) formatCapabilitiesRequest(m *gnmi.CapabilityRequest) ([
 		capReq.Extentions = append(capReq.Extentions, e.String())
 	}
 	if o.Multiline {
-		return json.MarshalIndent(capReq, o.Prefix, o.Indent)
+		return json.MarshalIndent(capReq, "", o.Indent)
 	}
 	return json.Marshal(capReq)
 }
@@ -204,7 +203,7 @@ func (o *MarshalOptions) formatCapabilitiesResponse(m *gnmi.CapabilityResponse) 
 		capRspMsg.Encodings = append(capRspMsg.Encodings, se.String())
 	}
 	if o.Multiline {
-		return json.MarshalIndent(capRspMsg, o.Prefix, o.Indent)
+		return json.MarshalIndent(capRspMsg, "", o.Indent)
 	}
 	return json.Marshal(capRspMsg)
 }
@@ -228,7 +227,7 @@ func (o *MarshalOptions) formatGetRequest(m *gnmi.GetRequest) ([]byte, error) {
 			})
 	}
 	if o.Multiline {
-		return json.MarshalIndent(msg, o.Prefix, o.Indent)
+		return json.MarshalIndent(msg, "", o.Indent)
 	}
 	return json.Marshal(msg)
 }
@@ -273,7 +272,7 @@ func (o *MarshalOptions) formatGetResponse(m *gnmi.GetResponse, meta map[string]
 		notifications = append(notifications, msg)
 	}
 	if o.Multiline {
-		return json.MarshalIndent(notifications, o.Prefix, o.Indent)
+		return json.MarshalIndent(notifications, "", o.Indent)
 	}
 	return json.Marshal(notifications)
 }
@@ -305,7 +304,7 @@ func (o *MarshalOptions) formatSetRequest(m *gnmi.SetRequest) ([]byte, error) {
 		})
 	}
 	if o.Multiline {
-		return json.MarshalIndent(req, o.Prefix, o.Indent)
+		return json.MarshalIndent(req, "", o.Indent)
 	}
 	return json.Marshal(req)
 }
@@ -329,7 +328,7 @@ func (o *MarshalOptions) formatSetResponse(m *gnmi.SetResponse, meta map[string]
 		})
 	}
 	if o.Multiline {
-		return json.MarshalIndent(msg, o.Prefix, o.Indent)
+		return json.MarshalIndent(msg, "", o.Indent)
 	}
 	return json.Marshal(msg)
 }

--- a/collector/formats.go
+++ b/collector/formats.go
@@ -54,9 +54,10 @@ func (o *MarshalOptions) Marshal(msg proto.Message, meta map[string]string) ([]b
 				}
 			}
 			return b, nil
+		default:
+			return nil, fmt.Errorf("format 'event' not supported for msg type %T", msg.ProtoReflect().Interface())
 		}
 	}
-	return nil, nil
 }
 
 // FormatJSON formats a proto.Message and returns a []byte and an error

--- a/collector/formats.go
+++ b/collector/formats.go
@@ -1,0 +1,335 @@
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+)
+
+type MarshalOptions struct {
+	Multiline bool // could get rid of this and deduct it from len(Indent)
+	Indent    string
+	Prefix    string
+	Format    string
+}
+
+// Marshal //
+func (o *MarshalOptions) Marshal(msg proto.Message, meta map[string]string) ([]byte, error) {
+	switch o.Format {
+	default: // json
+		return o.FormatJSON(msg, meta)
+	case "proto":
+		return proto.Marshal(msg)
+	case "protojson":
+		return protojson.MarshalOptions{Multiline: o.Multiline, Indent: o.Indent}.Marshal(msg)
+	case "prototext":
+		return prototext.MarshalOptions{Multiline: o.Multiline, Indent: o.Indent}.Marshal(msg)
+	case "event":
+		switch msg := msg.ProtoReflect().Interface().(type) {
+		case *gnmi.SubscribeResponse:
+			var subscriptionName string
+			var ok bool
+			if subscriptionName, ok = meta["subscription-name"]; !ok {
+				subscriptionName = "default"
+			}
+			b := make([]byte, 0)
+			switch msg.Response.(type) {
+			case *gnmi.SubscribeResponse_Update:
+				events, err := ResponseToEventMsgs(subscriptionName, msg, meta)
+				if err != nil {
+					return nil, fmt.Errorf("failed converting response to events: %v", err)
+				}
+				if o.Multiline {
+					b, err = json.MarshalIndent(events, "", o.Indent)
+				} else {
+					b, err = json.Marshal(events)
+				}
+				if err != nil {
+					return nil, fmt.Errorf("failed marshaling format 'event': %v", err)
+				}
+			}
+			return b, nil
+		}
+	}
+	return nil, nil
+}
+
+// FormatJSON formats a proto.Message and returns a []byte and an error
+func (o *MarshalOptions) FormatJSON(m proto.Message, meta map[string]string) ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	switch m := m.ProtoReflect().Interface().(type) {
+	case *gnmi.CapabilityRequest:
+		return o.formatCapabilitiesRequest(m)
+	case *gnmi.CapabilityResponse:
+		return o.formatCapabilitiesResponse(m)
+	case *gnmi.GetRequest:
+		return o.formatGetRequest(m)
+	case *gnmi.GetResponse:
+		return o.formatGetResponse(m, meta)
+	case *gnmi.SetRequest:
+		return o.formatSetRequest(m)
+	case *gnmi.SetResponse:
+		return o.formatSetResponse(m, meta)
+	case *gnmi.SubscribeRequest:
+		return o.formatsubscribeRequest(m)
+	case *gnmi.SubscribeResponse:
+		return o.formatSubscribeResponse(m, meta)
+	}
+	return nil, nil
+}
+
+func (o *MarshalOptions) formatsubscribeRequest(m *gnmi.SubscribeRequest) ([]byte, error) {
+	msg := subscribeReq{}
+	switch m := m.Request.(type) {
+	case *gnmi.SubscribeRequest_Subscribe:
+		msg.Subscribe.Prefix = gnmiPathToXPath(m.Subscribe.Prefix)
+		msg.Subscribe.Target = m.Subscribe.Prefix.Target
+		msg.Subscribe.Subscriptions = make([]subscription, 0, len(m.Subscribe.Subscription))
+		if m.Subscribe != nil {
+			msg.Subscribe.UseAliases = m.Subscribe.UseAliases
+			msg.Subscribe.AllowAggregation = m.Subscribe.AllowAggregation
+			msg.Subscribe.UpdatesOnly = m.Subscribe.UpdatesOnly
+			msg.Subscribe.Encoding = m.Subscribe.Encoding.String()
+			msg.Subscribe.Mode = m.Subscribe.Mode.String()
+			if m.Subscribe.Qos != nil {
+				msg.Subscribe.Qos = m.Subscribe.Qos.Marking
+			}
+			for _, sub := range m.Subscribe.Subscription {
+				msg.Subscribe.Subscriptions = append(msg.Subscribe.Subscriptions,
+					subscription{
+						Path:              gnmiPathToXPath(sub.Path),
+						Mode:              sub.GetMode().String(),
+						SampleInterval:    sub.SampleInterval,
+						HeartbeatInterval: sub.HeartbeatInterval,
+						SuppressRedundant: sub.SuppressRedundant,
+					})
+			}
+		}
+	case *gnmi.SubscribeRequest_Poll:
+		msg.Poll = new(poll)
+	case *gnmi.SubscribeRequest_Aliases:
+		msg.Aliases = make(map[string]string)
+		for _, a := range m.Aliases.GetAlias() {
+			msg.Aliases[a.Alias] = gnmiPathToXPath(a.Path)
+		}
+	}
+	if o.Multiline {
+		return json.MarshalIndent(msg, o.Prefix, o.Indent)
+	}
+	return json.Marshal(msg)
+}
+
+func (o *MarshalOptions) formatSubscribeResponse(m *gnmi.SubscribeResponse, meta map[string]string) ([]byte, error) {
+	switch m := m.Response.(type) {
+	case *gnmi.SubscribeResponse_Update:
+		msg := NotificationRspMsg{
+			Timestamp: m.Update.Timestamp,
+		}
+		t := time.Unix(0, m.Update.Timestamp)
+		msg.Time = &t
+		if meta == nil {
+			meta = make(map[string]string)
+		}
+		msg.Prefix = gnmiPathToXPath(m.Update.Prefix)
+		msg.Target = m.Update.Prefix.Target
+		if s, ok := meta["source"]; ok {
+			msg.Source = s
+		}
+		if s, ok := meta["system-name"]; ok {
+			msg.SystemName = s
+		}
+		if s, ok := meta["subscription-name"]; ok {
+			msg.SubscriptionName = s
+		}
+		for i, upd := range m.Update.Update {
+			pathElems := make([]string, 0, len(upd.Path.Elem))
+			for _, pElem := range upd.Path.Elem {
+				pathElems = append(pathElems, pElem.GetName())
+			}
+			value, err := getValue(upd.Val)
+			if err != nil {
+				return nil, err
+			}
+			msg.Updates = append(msg.Updates,
+				update{
+					Path:   gnmiPathToXPath(upd.Path),
+					Values: make(map[string]interface{}),
+				})
+			msg.Updates[i].Values[strings.Join(pathElems, "/")] = value
+		}
+		for _, del := range m.Update.Delete {
+			msg.Deletes = append(msg.Deletes, gnmiPathToXPath(del))
+		}
+		if o.Multiline {
+			return json.MarshalIndent(msg, o.Prefix, o.Indent)
+		}
+		return json.Marshal(msg)
+	}
+	return nil, nil
+}
+
+func (o *MarshalOptions) formatCapabilitiesRequest(m *gnmi.CapabilityRequest) ([]byte, error) {
+	capReq := capRequest{
+		Extentions: make([]string, 0, len(m.Extension)),
+	}
+	for _, e := range m.Extension {
+		capReq.Extentions = append(capReq.Extentions, e.String())
+	}
+	if o.Multiline {
+		return json.MarshalIndent(capReq, o.Prefix, o.Indent)
+	}
+	return json.Marshal(capReq)
+}
+
+func (o *MarshalOptions) formatCapabilitiesResponse(m *gnmi.CapabilityResponse) ([]byte, error) {
+	capRspMsg := capResponse{}
+	capRspMsg.Version = m.GetGNMIVersion()
+	for _, sm := range m.SupportedModels {
+		capRspMsg.SupportedModels = append(capRspMsg.SupportedModels,
+			model{
+				Name:         sm.GetName(),
+				Organization: sm.GetOrganization(),
+				Version:      sm.GetVersion(),
+			})
+	}
+	for _, se := range m.SupportedEncodings {
+		capRspMsg.Encodings = append(capRspMsg.Encodings, se.String())
+	}
+	if o.Multiline {
+		return json.MarshalIndent(capRspMsg, o.Prefix, o.Indent)
+	}
+	return json.Marshal(capRspMsg)
+}
+
+func (o *MarshalOptions) formatGetRequest(m *gnmi.GetRequest) ([]byte, error) {
+	msg := getRqMsg{
+		Prefix:   gnmiPathToXPath(m.Prefix),
+		Paths:    make([]string, 0, len(m.Path)),
+		Encoding: m.Encoding.String(),
+		DataType: m.Type.String(),
+	}
+	for _, p := range m.Path {
+		msg.Paths = append(msg.Paths, gnmiPathToXPath(p))
+	}
+	for _, um := range m.UseModels {
+		msg.Models = append(msg.Models,
+			model{
+				Name:         um.GetName(),
+				Organization: um.GetOrganization(),
+				Version:      um.GetVersion(),
+			})
+	}
+	if o.Multiline {
+		return json.MarshalIndent(msg, o.Prefix, o.Indent)
+	}
+	return json.Marshal(msg)
+}
+
+func (o *MarshalOptions) formatGetResponse(m *gnmi.GetResponse, meta map[string]string) ([]byte, error) {
+	notifications := make([]NotificationRspMsg, 0, len(m.Notification))
+	for _, notif := range m.Notification {
+		msg := NotificationRspMsg{
+			Prefix:  gnmiPathToXPath(notif.Prefix),
+			Updates: make([]update, 0, len(notif.Update)),
+			Deletes: make([]string, 0, len(notif.Delete)),
+		}
+		msg.Timestamp = notif.Timestamp
+		t := time.Unix(0, notif.Timestamp)
+		msg.Time = &t
+		if meta == nil {
+			meta = make(map[string]string)
+		}
+		msg.Prefix = gnmiPathToXPath(notif.Prefix)
+		if s, ok := meta["source"]; ok {
+			msg.Source = s
+		}
+		for i, upd := range notif.Update {
+			pathElems := make([]string, 0, len(upd.Path.Elem))
+			for _, pElem := range upd.Path.Elem {
+				pathElems = append(pathElems, pElem.GetName())
+			}
+			value, err := getValue(upd.Val)
+			if err != nil {
+				return nil, err
+			}
+			msg.Updates = append(msg.Updates,
+				update{
+					Path:   gnmiPathToXPath(upd.Path),
+					Values: make(map[string]interface{}),
+				})
+			msg.Updates[i].Values[strings.Join(pathElems, "/")] = value
+		}
+		for _, del := range notif.Delete {
+			msg.Deletes = append(msg.Deletes, gnmiPathToXPath(del))
+		}
+		notifications = append(notifications, msg)
+	}
+	if o.Multiline {
+		return json.MarshalIndent(notifications, o.Prefix, o.Indent)
+	}
+	return json.Marshal(notifications)
+}
+
+func (o *MarshalOptions) formatSetRequest(m *gnmi.SetRequest) ([]byte, error) {
+	req := setReqMsg{
+		Prefix:  gnmiPathToXPath(m.Prefix),
+		Delete:  make([]string, 0, len(m.Delete)),
+		Replace: make([]updateMsg, 0, len(m.Replace)),
+		Update:  make([]updateMsg, 0, len(m.Update)),
+	}
+
+	for _, del := range m.Delete {
+		p := gnmiPathToXPath(del)
+		req.Delete = append(req.Delete, p)
+	}
+
+	for _, upd := range m.Replace {
+		req.Replace = append(req.Replace, updateMsg{
+			Path: gnmiPathToXPath(upd.Path),
+			Val:  upd.Val.String(),
+		})
+	}
+
+	for _, upd := range m.Update {
+		req.Update = append(req.Update, updateMsg{
+			Path: gnmiPathToXPath(upd.Path),
+			Val:  upd.Val.String(),
+		})
+	}
+	if o.Multiline {
+		return json.MarshalIndent(req, o.Prefix, o.Indent)
+	}
+	return json.Marshal(req)
+}
+
+func (o *MarshalOptions) formatSetResponse(m *gnmi.SetResponse, meta map[string]string) ([]byte, error) {
+	msg := setRspMsg{}
+	msg.Prefix = gnmiPathToXPath(m.Prefix)
+	msg.Timestamp = m.Timestamp
+	msg.Time = time.Unix(0, m.Timestamp)
+	if meta == nil {
+		meta = make(map[string]string)
+	}
+	msg.Results = make([]updateResultMsg, 0, len(m.Response))
+	if s, ok := meta["source"]; ok {
+		msg.Source = s
+	}
+	for _, u := range m.Response {
+		msg.Results = append(msg.Results, updateResultMsg{
+			Operation: u.Op.String(),
+			Path:      gnmiPathToXPath(u.Path),
+		})
+	}
+	if o.Multiline {
+		return json.MarshalIndent(msg, o.Prefix, o.Indent)
+	}
+	return json.Marshal(msg)
+}

--- a/collector/msg.go
+++ b/collector/msg.go
@@ -2,14 +2,13 @@ package collector
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/openconfig/gnmi/proto/gnmi"
 )
 
-type msg struct {
+type NotificationRspMsg struct {
 	Meta             map[string]interface{} `json:"meta,omitempty"`
 	Source           string                 `json:"source,omitempty"`
 	SystemName       string                 `json:"system-name,omitempty"`
@@ -17,32 +16,116 @@ type msg struct {
 	Timestamp        int64                  `json:"timestamp,omitempty"`
 	Time             *time.Time             `json:"time,omitempty"`
 	Prefix           string                 `json:"prefix,omitempty"`
-	Updates          []*update              `json:"updates,omitempty"`
+	Target           string                 `json:"target,omitempty"`
+	Updates          []update               `json:"updates,omitempty"`
 	Deletes          []string               `json:"deletes,omitempty"`
 }
 type update struct {
 	Path   string
 	Values map[string]interface{} `json:"values,omitempty"`
 }
+type capRequest struct {
+	Extentions []string `json:"extentions,omitempty"`
+}
+type capResponse struct {
+	Version         string   `json:"version,omitempty"`
+	SupportedModels []model  `json:"supported-models,omitempty"`
+	Encodings       []string `json:"encodings,omitempty"`
+}
+type model struct {
+	Name         string `json:"name,omitempty"`
+	Organization string `json:"organization,omitempty"`
+	Version      string `json:"version,omitempty"`
+}
+
+type getRqMsg struct {
+	Prefix   string   `json:"prefix,omitempty"`
+	Paths    []string `json:"paths,omitempty"`
+	Encoding string   `json:"encoding,omitempty"`
+	DataType string   `json:"data-type,omitempty"`
+	Models   []model  `json:"models,omitempty"`
+}
+
+type setRspMsg struct {
+	Source    string            `json:"source,omitempty"`
+	Timestamp int64             `json:"timestamp,omitempty"`
+	Time      time.Time         `json:"time,omitempty"`
+	Prefix    string            `json:"prefix,omitempty"`
+	Results   []updateResultMsg `json:"results,omitempty"`
+}
+
+type updateResultMsg struct {
+	Operation string `json:"operation,omitempty"`
+	Path      string `json:"path,omitempty"`
+}
+
+type setReqMsg struct {
+	Prefix  string      `json:"prefix,omitempty"`
+	Delete  []string    `json:"delete,omitempty"`
+	Replace []updateMsg `json:"replace,omitempty"`
+	Update  []updateMsg `json:"update,omitempty"`
+	// extension is not implemented
+}
+
+type updateMsg struct {
+	Path string `json:"path,omitempty"`
+	Val  string `json:"val,omitempty"`
+}
+
+type subscribeReq struct {
+	Subscribe subscribe         `json:"subscribe,omitempty"`
+	Poll      *poll             `json:"poll,omitempty"`
+	Aliases   map[string]string `json:"aliases,omitempty"`
+}
+type poll struct{}
+type subscribe struct {
+	Target           string         `json:"target,omitempty"`
+	Prefix           string         `json:"prefix,omitempty"`
+	Subscriptions    []subscription `json:"subscriptions,omitempty"`
+	UseAliases       bool           `json:"use-aliases,omitempty"`
+	Qos              uint32         `json:"qos,omitempty"`
+	Mode             string         `json:"mode,omitempty"`
+	AllowAggregation bool           `json:"allow-aggregation,omitempty"`
+	UseModels        []model        `json:"use-models,omitempty"`
+	Encoding         string         `json:"encoding,omitempty"`
+	UpdatesOnly      bool           `json:"updates-only,omitempty"`
+}
+type subscription struct {
+	Path              string `json:"path,omitempty"`
+	Mode              string `json:"mode,omitempty"`
+	SampleInterval    uint64 `json:"sample-interval,omitempty"`
+	SuppressRedundant bool   `json:"suppress-redundant,omitempty"`
+	HeartbeatInterval uint64 `json:"heartbeat-interval,omitempty"`
+}
 
 func gnmiPathToXPath(p *gnmi.Path) string {
 	if p == nil {
 		return ""
 	}
-	pathElems := make([]string, 0, len(p.GetElem()))
-	for _, pe := range p.GetElem() {
-		elem := ""
-		if pe.GetName() != "" {
-			elem += pe.GetName()
-		}
-		if pe.GetKey() != nil {
-			for k, v := range pe.GetKey() {
-				elem += fmt.Sprintf("[%s=%s]", k, v)
-			}
-		}
-		pathElems = append(pathElems, elem)
+	sb := strings.Builder{}
+	if p.Origin != "" {
+		sb.WriteString(p.Origin)
+		sb.WriteString(":")
 	}
-	return strings.Join(pathElems, "/")
+	elems := p.GetElem()
+	numElems := len(elems)
+	if numElems > 0 {
+		sb.WriteString("/")
+	}
+	for i, pe := range elems {
+		sb.WriteString(pe.GetName())
+		for k, v := range pe.GetKey() {
+			sb.WriteString("[")
+			sb.WriteString(k)
+			sb.WriteString("=")
+			sb.WriteString(v)
+			sb.WriteString("]")
+		}
+		if i+1 != numElems {
+			sb.WriteString("/")
+		}
+	}
+	return sb.String()
 }
 
 func getValue(updValue *gnmi.TypedValue) (interface{}, error) {

--- a/collector/msg.go
+++ b/collector/msg.go
@@ -109,9 +109,6 @@ func gnmiPathToXPath(p *gnmi.Path) string {
 	}
 	elems := p.GetElem()
 	numElems := len(elems)
-	if numElems > 0 {
-		sb.WriteString("/")
-	}
 	for i, pe := range elems {
 		sb.WriteString(pe.GetName())
 		for k, v := range pe.GetKey() {

--- a/collector/target.go
+++ b/collector/target.go
@@ -214,8 +214,8 @@ func (t *Target) Subscribe(ctx context.Context, req *gnmi.SubscribeRequest, subs
 }
 
 // Export //
-func (t *Target) Export(msg []byte, m outputs.Meta) {
-	if len(msg) == 0 || len(t.Outputs) == 0 {
+func (t *Target) Export(rsp *gnmi.SubscribeResponse, m outputs.Meta) {
+	if rsp == nil || len(t.Outputs) == 0 {
 		return
 	}
 	wg := new(sync.WaitGroup)
@@ -223,7 +223,7 @@ func (t *Target) Export(msg []byte, m outputs.Meta) {
 	for _, o := range t.Outputs {
 		go func(o outputs.Output) {
 			defer wg.Done()
-			o.Write(msg, m)
+			o.Write(rsp, m)
 		}(o)
 	}
 	wg.Wait()

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/gnxi v0.0.0-20200508145201-92c6d0d3ec3b
 	github.com/google/uuid v1.1.1
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/jeremywohl/flatten v1.0.1
 	github.com/karimra/sros-dialout v0.0.0-20200518085040-c759bf74063a
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/jeremywohl/flatten v1.0.1
+	github.com/karimra/go-map-flattener v0.0.0-20200722050030-b900ba59d8a5
 	github.com/karimra/sros-dialout v0.0.0-20200518085040-c759bf74063a
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/jeremywohl/flatten v1.0.1
-	github.com/karimra/go-map-flattener v0.0.0-20200722050030-b900ba59d8a5
+	github.com/karimra/go-map-flattener v0.0.0-20200728034653-b1473e58dae8
 	github.com/karimra/sros-dialout v0.0.0-20200518085040-c759bf74063a
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/karimra/gnmiClient v0.0.6 h1:YNB3WG8CxwF/l6tO8vmqCCJWo9r9RrZcfa4Ns7kBqfM=
 github.com/karimra/gnmiClient v0.0.6/go.mod h1:bbZcxou9j6SIhkno6YiOd/QKIAqwq00pgMm0GshTpyE=
+github.com/karimra/go-map-flattener v0.0.0-20200722050030-b900ba59d8a5 h1:KZYo3zRTDBIINaGev4S8ihxQt8Rg21UYpaDv8ItYaQQ=
+github.com/karimra/go-map-flattener v0.0.0-20200722050030-b900ba59d8a5/go.mod h1:qwSIH4cR7eD1dkmjx0S/rqsO33C6VYaTHLrdfntJQkM=
 github.com/karimra/sros-dialout v0.0.0-20200518085040-c759bf74063a h1:OLIlAOVZsQFJixMQFNMxIQb2tU8OCcEtDtSVbbeLWAM=
 github.com/karimra/sros-dialout v0.0.0-20200518085040-c759bf74063a/go.mod h1:KcjPi49Pbs+EF8Ykob5AzLcze653Qb4HFz+i2aFEEJU=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,8 @@ github.com/karimra/gnmiClient v0.0.6 h1:YNB3WG8CxwF/l6tO8vmqCCJWo9r9RrZcfa4Ns7kB
 github.com/karimra/gnmiClient v0.0.6/go.mod h1:bbZcxou9j6SIhkno6YiOd/QKIAqwq00pgMm0GshTpyE=
 github.com/karimra/go-map-flattener v0.0.0-20200722050030-b900ba59d8a5 h1:KZYo3zRTDBIINaGev4S8ihxQt8Rg21UYpaDv8ItYaQQ=
 github.com/karimra/go-map-flattener v0.0.0-20200722050030-b900ba59d8a5/go.mod h1:qwSIH4cR7eD1dkmjx0S/rqsO33C6VYaTHLrdfntJQkM=
+github.com/karimra/go-map-flattener v0.0.0-20200728034653-b1473e58dae8 h1:drle12vIpTVckWi44El+2ukPs0wrpRMlyIwvdLD4dNw=
+github.com/karimra/go-map-flattener v0.0.0-20200728034653-b1473e58dae8/go.mod h1:qwSIH4cR7eD1dkmjx0S/rqsO33C6VYaTHLrdfntJQkM=
 github.com/karimra/sros-dialout v0.0.0-20200518085040-c759bf74063a h1:OLIlAOVZsQFJixMQFNMxIQb2tU8OCcEtDtSVbbeLWAM=
 github.com/karimra/sros-dialout v0.0.0-20200518085040-c759bf74063a/go.mod h1:KcjPi49Pbs+EF8Ykob5AzLcze653Qb4HFz+i2aFEEJU=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jcmturner/gofork v1.0.0 h1:J7uCkflzTEhUZ64xqKnkDxq3kzc96ajM1Gli5ktUem8=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
+github.com/jeremywohl/flatten v1.0.1 h1:LrsxmB3hfwJuE+ptGOijix1PIfOoKLJ3Uee/mzbgtrs=
+github.com/jeremywohl/flatten v1.0.1/go.mod h1:4AmD/VxjWcI5SRB0n6szE2A6s2fsNHDLO0nAlMHgfLQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/outputs/file/file.go
+++ b/outputs/file/file.go
@@ -80,7 +80,8 @@ func (f *File) Init(cfg map[string]interface{}, logger *log.Logger) error {
 	if f.Cfg.Format == "" {
 		f.Cfg.Format = "json"
 	}
-	if (f.Cfg.Format == "json" || f.Cfg.Format == "textproto") && (f.Cfg.FileType == "stdout" || f.Cfg.FileType == "stderr") {
+	if (f.Cfg.Format == "json" || f.Cfg.Format == "prototext" || f.Cfg.Format == "event" || f.Cfg.Format == "protojson") &&
+		(f.Cfg.FileType == "stdout" || f.Cfg.FileType == "stderr") {
 		f.Cfg.Indent = "  "
 		f.Cfg.Multiline = true
 	}

--- a/outputs/file/file.go
+++ b/outputs/file/file.go
@@ -67,7 +67,7 @@ func (f *File) Init(cfg map[string]interface{}, logger *log.Logger) error {
 		return fmt.Errorf("proto format not supported in output type 'file'")
 	}
 	if f.Cfg.Separator == "" {
-		f.Cfg.Separator = "\n"
+		f.Cfg.Separator = defaultSeparator
 	}
 	if f.Cfg.FileName == "" && f.Cfg.FileType == "" {
 		f.Cfg.FileType = "stdout"
@@ -89,7 +89,7 @@ func (f *File) Init(cfg map[string]interface{}, logger *log.Logger) error {
 		f.logger.SetFlags(logger.Flags())
 	}
 	if f.Cfg.Format == "" {
-		f.Cfg.Format = "json"
+		f.Cfg.Format = defaultFormat
 	}
 	if f.Cfg.FileType == "stdout" || f.Cfg.FileType == "stderr" {
 		f.Cfg.Indent = "  "

--- a/outputs/file/file.go
+++ b/outputs/file/file.go
@@ -76,7 +76,7 @@ func (f *File) Init(cfg map[string]interface{}, logger *log.Logger) error {
 		f.logger.SetFlags(logger.Flags())
 	}
 	if f.Cfg.Format == "" {
-		f.Cfg.Format = "event"
+		f.Cfg.Format = "json"
 	}
 	f.logger.Printf("initialized file output: %s", f.String())
 	return nil

--- a/outputs/file/file.go
+++ b/outputs/file/file.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"time"
 
 	"github.com/karimra/gnmic/collector"
 	"github.com/karimra/gnmic/outputs"
@@ -17,7 +16,6 @@ import (
 const (
 	defaultFormat    = "json"
 	defaultSeparator = "\n"
-	defaultFileName  = "gnmic"
 )
 
 func init() {
@@ -71,22 +69,20 @@ func (f *File) Init(cfg map[string]interface{}, logger *log.Logger) error {
 	if f.Cfg.Separator == "" {
 		f.Cfg.Separator = "\n"
 	}
-	if f.Cfg.FileName == "" {
-		f.Cfg.FileName = fmt.Sprintf("%s-%s.log", defaultFileName, time.Now().Format("2006-01-02"))
+	if f.Cfg.FileName == "" && f.Cfg.FileType == "" {
+		f.Cfg.FileType = "stdout"
 	}
-	var file *os.File
 	switch f.Cfg.FileType {
 	case "stdout":
-		file = os.Stdout
+		f.file = os.Stdout
 	case "stderr":
-		file = os.Stderr
+		f.file = os.Stderr
 	default:
-		file, err = os.OpenFile(f.Cfg.FileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		f.file, err = os.OpenFile(f.Cfg.FileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 		if err != nil {
 			return err
 		}
 	}
-	f.file = file
 	f.logger = log.New(os.Stderr, "file_output ", log.LstdFlags|log.Lmicroseconds)
 	if logger != nil {
 		f.logger.SetOutput(logger.Writer())

--- a/outputs/kafka_output/kafka_output.go
+++ b/outputs/kafka_output/kafka_output.go
@@ -21,6 +21,8 @@ const (
 	defaultKafkaMaxRetry = 2
 	defaultKafkaTimeout  = 5
 	defaultKafkaTopic    = "telemetry"
+
+	defaultFormat = "json"
 )
 
 func init() {

--- a/outputs/kafka_output/kafka_output.go
+++ b/outputs/kafka_output/kafka_output.go
@@ -2,6 +2,7 @@ package kafka_output
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -61,6 +62,12 @@ func (k *KafkaOutput) Init(cfg map[string]interface{}, logger *log.Logger) error
 	err := mapstructure.Decode(cfg, k.Cfg)
 	if err != nil {
 		return err
+	}
+	if k.Cfg.Format == "" {
+		k.Cfg.Format = "event"
+	}
+	if !(k.Cfg.Format == "event" || k.Cfg.Format == "protojson" || k.Cfg.Format == "proto" || k.Cfg.Format == "json") {
+		return fmt.Errorf("unsupported output format: %s", k.Cfg.Format)
 	}
 	if k.Cfg.Topic == "" {
 		k.Cfg.Topic = defaultKafkaTopic

--- a/outputs/kafka_output/kafka_output.go
+++ b/outputs/kafka_output/kafka_output.go
@@ -64,7 +64,7 @@ func (k *KafkaOutput) Init(cfg map[string]interface{}, logger *log.Logger) error
 		return err
 	}
 	if k.Cfg.Format == "" {
-		k.Cfg.Format = "event"
+		k.Cfg.Format = "json"
 	}
 	if !(k.Cfg.Format == "event" || k.Cfg.Format == "protojson" || k.Cfg.Format == "proto" || k.Cfg.Format == "json") {
 		return fmt.Errorf("unsupported output format: %s", k.Cfg.Format)

--- a/outputs/kafka_output/kafka_output.go
+++ b/outputs/kafka_output/kafka_output.go
@@ -39,6 +39,7 @@ type KafkaOutput struct {
 	producer sarama.SyncProducer
 	metrics  []prometheus.Collector
 	logger   sarama.StdLogger
+	mo       *collector.MarshalOptions
 }
 
 // Config //
@@ -101,6 +102,7 @@ func (k *KafkaOutput) Init(cfg map[string]interface{}, logger *log.Logger) error
 	if err != nil {
 		return err
 	}
+	k.mo = &collector.MarshalOptions{Format: k.Cfg.Format}
 	k.logger.Printf("initialized kafka producer: %s", k.String())
 	return err
 }
@@ -115,7 +117,7 @@ func (k *KafkaOutput) Write(rsp proto.Message, meta outputs.Meta) {
 			return
 		}
 	}
-	b, err := collector.Marshal(rsp, k.Cfg.Format, meta, false, "")
+	b, err := k.mo.Marshal(rsp, meta)
 	if err != nil {
 		k.logger.Printf("failed marshaling proto msg: %v", err)
 		return

--- a/outputs/kafka_output/kafka_output.go
+++ b/outputs/kafka_output/kafka_output.go
@@ -67,7 +67,7 @@ func (k *KafkaOutput) Init(cfg map[string]interface{}, logger *log.Logger) error
 		k.Cfg.Format = "json"
 	}
 	if !(k.Cfg.Format == "event" || k.Cfg.Format == "protojson" || k.Cfg.Format == "proto" || k.Cfg.Format == "json") {
-		return fmt.Errorf("unsupported output format: %s", k.Cfg.Format)
+		return fmt.Errorf("unsupported output format '%s' for output type kafka", k.Cfg.Format)
 	}
 	if k.Cfg.Topic == "" {
 		k.Cfg.Topic = defaultKafkaTopic

--- a/outputs/kafka_output/kafka_output.go
+++ b/outputs/kafka_output/kafka_output.go
@@ -109,7 +109,7 @@ func (k *KafkaOutput) Write(rsp proto.Message, meta outputs.Meta) {
 		return
 	}
 	if format, ok := meta["format"]; ok {
-		if format == "textproto" {
+		if format == "prototext" {
 			return
 		}
 	}

--- a/outputs/kafka_output/kafka_output.go
+++ b/outputs/kafka_output/kafka_output.go
@@ -66,7 +66,7 @@ func (k *KafkaOutput) Init(cfg map[string]interface{}, logger *log.Logger) error
 		return err
 	}
 	if k.Cfg.Format == "" {
-		k.Cfg.Format = "json"
+		k.Cfg.Format = defaultFormat
 	}
 	if !(k.Cfg.Format == "event" || k.Cfg.Format == "protojson" || k.Cfg.Format == "proto" || k.Cfg.Format == "json") {
 		return fmt.Errorf("unsupported output format '%s' for output type kafka", k.Cfg.Format)

--- a/outputs/nats_output/natsOutput.go
+++ b/outputs/nats_output/natsOutput.go
@@ -46,6 +46,7 @@ type NatsOutput struct {
 	conn     *nats.Conn
 	metrics  []prometheus.Collector
 	logger   *log.Logger
+	mo       *collector.MarshalOptions
 }
 
 // Config //
@@ -100,6 +101,7 @@ func (n *NatsOutput) Init(cfg map[string]interface{}, logger *log.Logger) error 
 		return err
 	}
 	n.logger.Printf("initialized nats producer: %s", n.String())
+	n.mo = &collector.MarshalOptions{Format: n.Cfg.Format}
 	return nil
 }
 
@@ -130,7 +132,7 @@ func (n *NatsOutput) Write(rsp proto.Message, meta outputs.Meta) {
 		ssb.WriteString(n.Cfg.Subject)
 	}
 	subject := strings.ReplaceAll(ssb.String(), " ", "_")
-	b, err := collector.Marshal(rsp, n.Cfg.Format, meta, false, "")
+	b, err := n.mo.Marshal(rsp, meta)
 	if err != nil {
 		n.logger.Printf("failed marshaling proto msg: %v", err)
 		return

--- a/outputs/nats_output/natsOutput.go
+++ b/outputs/nats_output/natsOutput.go
@@ -142,7 +142,7 @@ func (n *NatsOutput) Write(rsp proto.Message, meta outputs.Meta) {
 	case "proto":
 		b, err = proto.Marshal(rsp)
 	case "json":
-		b, err = protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(rsp)
+		b, err = protojson.Marshal(rsp)
 	case "event":
 		switch sub := rsp.ProtoReflect().Interface().(type) {
 		case *gnmi.SubscribeResponse:
@@ -158,7 +158,7 @@ func (n *NatsOutput) Write(rsp proto.Message, meta outputs.Meta) {
 					n.logger.Printf("failed converting response to events: %v", err)
 					return
 				}
-				b, err = json.MarshalIndent(events, "", "  ")
+				b, err = json.Marshal(events)
 				if err != nil {
 					n.logger.Printf("failed marshaling events: %v", err)
 					return

--- a/outputs/nats_output/natsOutput.go
+++ b/outputs/nats_output/natsOutput.go
@@ -91,7 +91,7 @@ func (n *NatsOutput) Init(cfg map[string]interface{}, logger *log.Logger) error 
 		n.logger.SetFlags(logger.Flags())
 	}
 	if n.Cfg.Format == "" {
-		n.Cfg.Format = "event"
+		n.Cfg.Format = "json"
 	}
 	if !(n.Cfg.Format == "event" || n.Cfg.Format == "protojson" || n.Cfg.Format == "proto" || n.Cfg.Format == "json") {
 		return fmt.Errorf("unsupported output format: %s", n.Cfg.Format)

--- a/outputs/nats_output/natsOutput.go
+++ b/outputs/nats_output/natsOutput.go
@@ -15,7 +15,6 @@ import (
 	"github.com/karimra/gnmic/outputs"
 	"github.com/mitchellh/mapstructure"
 	"github.com/nats-io/nats.go"
-	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/protobuf/proto"
 )
@@ -28,12 +27,6 @@ const (
 
 	defaultSubjectName = "gnmic-telemetry"
 )
-
-type msg struct {
-	Tags     outputs.Meta  `json:"tags,omitempty"`
-	Msg      proto.Message `json:"msg,omitempty"`
-	MsgBytes []byte        `json:"msg_bytes,omitempty"`
-}
 
 func init() {
 	outputs.Register("nats", func() outputs.Output {
@@ -122,14 +115,14 @@ func (n *NatsOutput) Write(rsp proto.Message, meta outputs.Meta) {
 	ssb.WriteString(n.Cfg.SubjectPrefix)
 	if n.Cfg.SubjectPrefix != "" {
 		if s, ok := meta["source"]; ok {
-			source := strings.ReplaceAll(fmt.Sprintf("%s", s), ".", "-")
+			source := strings.ReplaceAll(s, ".", "-")
 			source = strings.ReplaceAll(source, " ", "_")
 			ssb.WriteString(".")
 			ssb.WriteString(source)
 		}
 		if subname, ok := meta["subscription-name"]; ok {
 			ssb.WriteString(".")
-			ssb.WriteString(fmt.Sprintf("%s", subname))
+			ssb.WriteString(subname)
 		}
 	} else if n.Cfg.Subject != "" {
 		ssb.WriteString(n.Cfg.Subject)
@@ -207,9 +200,4 @@ func (n *NatsOutput) Dial(network, address string) (net.Conn, error) {
 			time.Sleep(n.Cfg.ConnectTimeWait)
 		}
 	}
-}
-
-func (n *NatsOutput) marshal(rsp *gnmi.SubscribeResponse, meta outputs.Meta) ([]byte, error) {
-
-	return nil, nil
 }

--- a/outputs/nats_output/natsOutput.go
+++ b/outputs/nats_output/natsOutput.go
@@ -93,7 +93,7 @@ func (n *NatsOutput) Init(cfg map[string]interface{}, logger *log.Logger) error 
 	if n.Cfg.Format == "" {
 		n.Cfg.Format = "event"
 	}
-	if !(n.Cfg.Format == "event" || n.Cfg.Format == "json" || n.Cfg.Format == "proto") {
+	if !(n.Cfg.Format == "event" || n.Cfg.Format == "protojson" || n.Cfg.Format == "proto" || n.Cfg.Format == "json") {
 		return fmt.Errorf("unsupported output format: %s", n.Cfg.Format)
 	}
 	if n.Cfg.Name == "" {

--- a/outputs/nats_output/natsOutput.go
+++ b/outputs/nats_output/natsOutput.go
@@ -114,7 +114,7 @@ func (n *NatsOutput) Write(rsp proto.Message, meta outputs.Meta) {
 		return
 	}
 	if format, ok := meta["format"]; ok {
-		if format == "textproto" {
+		if format == "prototext" {
 			return
 		}
 	}

--- a/outputs/nats_output/natsOutput.go
+++ b/outputs/nats_output/natsOutput.go
@@ -86,7 +86,7 @@ func (n *NatsOutput) Init(cfg map[string]interface{}, logger *log.Logger) error 
 		n.logger.SetFlags(logger.Flags())
 	}
 	if n.Cfg.Format == "" {
-		n.Cfg.Format = "json"
+		n.Cfg.Format = defaultFormat
 	}
 	if !(n.Cfg.Format == "event" || n.Cfg.Format == "protojson" || n.Cfg.Format == "proto" || n.Cfg.Format == "json") {
 		return fmt.Errorf("unsupported output format '%s' for output type NATS", n.Cfg.Format)

--- a/outputs/nats_output/natsOutput.go
+++ b/outputs/nats_output/natsOutput.go
@@ -94,7 +94,7 @@ func (n *NatsOutput) Init(cfg map[string]interface{}, logger *log.Logger) error 
 		n.Cfg.Format = "json"
 	}
 	if !(n.Cfg.Format == "event" || n.Cfg.Format == "protojson" || n.Cfg.Format == "proto" || n.Cfg.Format == "json") {
-		return fmt.Errorf("unsupported output format: %s", n.Cfg.Format)
+		return fmt.Errorf("unsupported output format '%s' for output type NATS", n.Cfg.Format)
 	}
 	if n.Cfg.Name == "" {
 		n.Cfg.Name = "gnmic-" + uuid.New().String()

--- a/outputs/nats_output/natsOutput.go
+++ b/outputs/nats_output/natsOutput.go
@@ -26,6 +26,8 @@ const (
 	natsReconnectBufferSize = 100 * 1024 * 1024
 
 	defaultSubjectName = "gnmic-telemetry"
+
+	defaultFormat = "json"
 )
 
 func init() {

--- a/outputs/output.go
+++ b/outputs/output.go
@@ -4,11 +4,12 @@ import (
 	"log"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/proto"
 )
 
 type Output interface {
 	Init(map[string]interface{}, *log.Logger) error
-	Write([]byte, Meta)
+	Write(proto.Message, Meta)
 	Close() error
 	Metrics() []prometheus.Collector
 	String() string
@@ -21,4 +22,4 @@ func Register(name string, initFn Initializer) {
 	Outputs[name] = initFn
 }
 
-type Meta map[string]interface{}
+type Meta map[string]string

--- a/outputs/stan_output/stan_output.go
+++ b/outputs/stan_output/stan_output.go
@@ -136,7 +136,7 @@ func (s *StanOutput) Write(rsp protoreflect.ProtoMessage, meta outputs.Meta) {
 	case "proto":
 		b, err = proto.Marshal(rsp)
 	case "json":
-		b, err = protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(rsp)
+		b, err = protojson.Marshal(rsp)
 	case "event":
 		switch sub := rsp.ProtoReflect().Interface().(type) {
 		case *gnmi.SubscribeResponse:
@@ -152,7 +152,7 @@ func (s *StanOutput) Write(rsp protoreflect.ProtoMessage, meta outputs.Meta) {
 					s.logger.Printf("failed converting response to events: %v", err)
 					return
 				}
-				b, err = json.MarshalIndent(events, "", "  ")
+				b, err = json.Marshal(events)
 				if err != nil {
 					s.logger.Printf("failed marshaling events: %v", err)
 					return

--- a/outputs/stan_output/stan_output.go
+++ b/outputs/stan_output/stan_output.go
@@ -92,7 +92,7 @@ func (s *StanOutput) Init(cfg map[string]interface{}, logger *log.Logger) error 
 	if s.Cfg.Format == "" {
 		s.Cfg.Format = "event"
 	}
-	if !(s.Cfg.Format == "event" || s.Cfg.Format == "json" || s.Cfg.Format == "proto") {
+	if !(s.Cfg.Format == "event" || s.Cfg.Format == "protojson" || s.Cfg.Format == "proto" || s.Cfg.Format == "json") {
 		return fmt.Errorf("unsupported output format: %s", s.Cfg.Format)
 	}
 	s.stopChan = make(chan struct{})
@@ -104,11 +104,6 @@ func (s *StanOutput) Init(cfg map[string]interface{}, logger *log.Logger) error 
 func (s *StanOutput) Write(rsp protoreflect.ProtoMessage, meta outputs.Meta) {
 	if rsp == nil {
 		return
-	}
-	if format, ok := meta["format"]; ok {
-		if format == "textproto" {
-			return
-		}
 	}
 	ssb := strings.Builder{}
 	ssb.WriteString(s.Cfg.SubjectPrefix)

--- a/outputs/stan_output/stan_output.go
+++ b/outputs/stan_output/stan_output.go
@@ -93,7 +93,7 @@ func (s *StanOutput) Init(cfg map[string]interface{}, logger *log.Logger) error 
 		s.Cfg.Format = "json"
 	}
 	if !(s.Cfg.Format == "event" || s.Cfg.Format == "protojson" || s.Cfg.Format == "proto" || s.Cfg.Format == "json") {
-		return fmt.Errorf("unsupported output format: %s", s.Cfg.Format)
+		return fmt.Errorf("unsupported output format: '%s' for output type STAN", s.Cfg.Format)
 	}
 	s.stopChan = make(chan struct{})
 	s.logger.Printf("initialized stan producer: %s", s.String())

--- a/outputs/stan_output/stan_output.go
+++ b/outputs/stan_output/stan_output.go
@@ -92,7 +92,7 @@ func (s *StanOutput) Init(cfg map[string]interface{}, logger *log.Logger) error 
 		s.logger.SetFlags(logger.Flags())
 	}
 	if s.Cfg.Format == "" {
-		s.Cfg.Format = "json"
+		s.Cfg.Format = defaultFormat
 	}
 	if !(s.Cfg.Format == "event" || s.Cfg.Format == "protojson" || s.Cfg.Format == "proto" || s.Cfg.Format == "json") {
 		return fmt.Errorf("unsupported output format: '%s' for output type STAN", s.Cfg.Format)

--- a/outputs/stan_output/stan_output.go
+++ b/outputs/stan_output/stan_output.go
@@ -23,6 +23,8 @@ const (
 	stanDefaultPingRetry    = 2
 
 	defaultSubjectName = "gnmic-telemetry"
+
+	defaultFormat = "json"
 )
 
 func init() {

--- a/outputs/stan_output/stan_output.go
+++ b/outputs/stan_output/stan_output.go
@@ -90,7 +90,7 @@ func (s *StanOutput) Init(cfg map[string]interface{}, logger *log.Logger) error 
 		s.logger.SetFlags(logger.Flags())
 	}
 	if s.Cfg.Format == "" {
-		s.Cfg.Format = "event"
+		s.Cfg.Format = "json"
 	}
 	if !(s.Cfg.Format == "event" || s.Cfg.Format == "protojson" || s.Cfg.Format == "proto" || s.Cfg.Format == "json") {
 		return fmt.Errorf("unsupported output format: %s", s.Cfg.Format)

--- a/outputs/stan_output/stan_output.go
+++ b/outputs/stan_output/stan_output.go
@@ -109,14 +109,14 @@ func (s *StanOutput) Write(rsp protoreflect.ProtoMessage, meta outputs.Meta) {
 	ssb.WriteString(s.Cfg.SubjectPrefix)
 	if s.Cfg.SubjectPrefix != "" {
 		if s, ok := meta["source"]; ok {
-			source := strings.ReplaceAll(fmt.Sprintf("%s", s), ".", "-")
+			source := strings.ReplaceAll(s, ".", "-")
 			source = strings.ReplaceAll(source, " ", "_")
 			ssb.WriteString(".")
 			ssb.WriteString(source)
 		}
 		if subname, ok := meta["subscription-name"]; ok {
 			ssb.WriteString(".")
-			ssb.WriteString(fmt.Sprintf("%s", subname))
+			ssb.WriteString(subname)
 		}
 	} else if s.Cfg.Subject != "" {
 		ssb.WriteString(s.Cfg.Subject)


### PR DESCRIPTION
Rework Output interface:
- Write() method takes a proto.Message instead of a []byte: 
   - This moves the message formatting to the output.
   - Allows to support different formats in different outputs for the same message
   - Allows to support more output formats/destination (influx, elasticsearch,...)
- File output takes a multiline, indent and a separator config options:
   - multiline and indent allow to pretty print json, prototext and protojson formats