### PR TITLE
improved installer script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -99,7 +99,7 @@ checkGnmicInstalledVersion() {
     if [[ -f "${GNMIC_INSTALL_DIR}/${BINARY_NAME}" ]]; then
         local version=$("${GNMIC_INSTALL_DIR}/${BINARY_NAME}" version | head -1 | awk '{print $NF}')
         if [[ "v$version" == "$TAG" ]]; then
-            echo "gnmic is already ${DESIRED_VERSION:-latest}"
+            echo "gnmic is already at ${DESIRED_VERSION:-latest}" version. Exiting...
             return 0
         else
             echo "gnmic ${TAG_WO_VER} is available. Changing from version ${version}."
@@ -237,11 +237,11 @@ set +u
 initArch
 initOS
 verifySupported
-verifyOpenssl
 setDesiredVersion
 if ! checkGnmicInstalledVersion; then
+    verifyOpenssl
     downloadFile
     installFile
+    testVersion
+    cleanup
 fi
-testVersion
-cleanup

--- a/install.sh
+++ b/install.sh
@@ -99,7 +99,7 @@ checkGnmicInstalledVersion() {
     if [[ -f "${GNMIC_INSTALL_DIR}/${BINARY_NAME}" ]]; then
         local version=$("${GNMIC_INSTALL_DIR}/${BINARY_NAME}" version | head -1 | awk '{print $NF}')
         if [[ "v$version" == "$TAG" ]]; then
-            echo "gnmic is already at ${DESIRED_VERSION:-latest}" version. Exiting...
+            echo "gnmic is already at ${DESIRED_VERSION:-latest ($version)}" version
             return 0
         else
             echo "gnmic ${TAG_WO_VER} is available. Changing from version ${version}."
@@ -150,7 +150,7 @@ installFile() {
     GNMIC_TMP_BIN="$GNMIC_TMP/gnmic"
     echo "Preparing to install $BINARY_NAME ${TAG_WO_VER} into ${GNMIC_INSTALL_DIR}"
     runAsRoot cp "$GNMIC_TMP_BIN" "$GNMIC_INSTALL_DIR/$BINARY_NAME"
-    echo "$BINARY_NAME ${TAG_WO_VER} installed into $GNMIC_INSTALL_DIR/$BINARY_NAME"
+    echo "$BINARY_NAME installed into $GNMIC_INSTALL_DIR/$BINARY_NAME"
 }
 
 # fail_trap is executed if an error occurs.
@@ -172,7 +172,7 @@ fail_trap() {
 # testVersion tests the installed client to make sure it is working.
 testVersion() {
     set +e
-    GNMIC="$($GNMIC_INSTALL_DIR/$BINARY_NAME version)"
+    $GNMIC_INSTALL_DIR/$BINARY_NAME version
     if [ "$?" = "1" ]; then
         echo "$BINARY_NAME not found. Is $GNMIC_INSTALL_DIR in your "'$PATH?'
         exit 1

--- a/install.sh
+++ b/install.sh
@@ -172,9 +172,9 @@ fail_trap() {
 # testVersion tests the installed client to make sure it is working.
 testVersion() {
     set +e
-    HELM="$(command -v $BINARY_NAME)"
+    GNMIC="$($BINARY_NAME version)"
     if [ "$?" = "1" ]; then
-        echo "$BINARY_NAME not found. Is $GNMIC_INSTALL_DIR on your "'$PATH?'
+        echo "$BINARY_NAME not found. Is $GNMIC_INSTALL_DIR in your "'$PATH?'
         exit 1
     fi
     set -e

--- a/install.sh
+++ b/install.sh
@@ -1,25 +1,247 @@
+#!/usr/bin/env bash
+
+# The install script is based off of the Apache 2.0 script from Helm,
+# https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+
+: ${BINARY_NAME:="gnmic"}
+: ${USE_SUDO:="true"}
+: ${VERIFY_CHECKSUM:="true"}
+: ${GNMIC_INSTALL_DIR:="/usr/local/bin"}
+
+# initArch discovers the architecture for this system.
+initArch() {
+    ARCH=$(uname -m)
+    # case $ARCH in
+    # armv5*) ARCH="armv5" ;;
+    # armv6*) ARCH="armv6" ;;
+    # armv7*) ARCH="arm" ;;
+    # aarch64) ARCH="arm64" ;;
+    # x86) ARCH="386" ;;
+    # x86_64) ARCH="amd64" ;;
+    # i686) ARCH="386" ;;
+    # i386) ARCH="386" ;;
+    # esac
+}
+
+# initOS discovers the operating system for this system.
+initOS() {
+    OS=$(echo $(uname) | tr '[:upper:]' '[:lower:]')
+
+    case "$OS" in
+    # Minimalist GNU for Windows
+    mingw*) OS='windows' ;;
+    esac
+}
+
+# runs the given command as root (detects if we are root already)
+runAsRoot() {
+    local CMD="$*"
+
+    if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
+        CMD="sudo $CMD"
+    fi
+
+    $CMD
+}
+
+# verifySupported checks that the os/arch combination is supported for
+# binary builds.
+verifySupported() {
+    local supported="darwin-i386\ndarwin-x86_64\nlinux-i386\nlinux-x86_64\nlinux-armv7\nlinux-aarch64\nwindows-i386\nwindows-x86_64"
+    if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
+        echo "No prebuilt binary for ${OS}-${ARCH}."
+        echo "To build from source, go to https://github.com/karimra/gnmic"
+        exit 1
+    fi
+
+    if ! type "curl" &>/dev/null && ! type "wget" &>/dev/null; then
+        echo "Either curl or wget is required"
+        exit 1
+    fi
+}
+
+# verifyOpenssl checks if openssl is installed to perform checksum operation
+verifyOpenssl() {
+    if [ $VERIFY_CHECKSUM == "true" ]; then
+        if ! type "openssl" &>/dev/null; then
+            echo "openssl is not found. Either install openssl or provide '--skip-checksum' flag to the installer"
+            exit 1
+        fi
+    fi
+}
+
+# setDesiredVersion sets the desired version either to an explicit version provided by a user
+# or to the latest release available on github releases
+setDesiredVersion() {
+    if [ "x$DESIRED_VERSION" == "x" ]; then
+        # when desired version is not provided
+        # get latest tag from the gh releases
+        if type "curl" &>/dev/null; then
+            local latest_release_url=$(curl -s https://github.com/karimra/gnmic/releases/latest | cut -d '"' -f 2)
+            TAG=$(echo $latest_release_url | cut -d '"' -f 2 | awk -F "/" '{print $NF}')
+            # tag with stripped `v` prefix
+            TAG_WO_VER=$(echo "${TAG}" | cut -c 2-)
+        elif type "wget" &>/dev/null; then
+            # get latest release info and get 5th line out of the response to get the URL
+            local latest_release_url=$(wget -q https://api.github.com/repos/karimra/gnmic/releases/latest -O- | sed '5q;d' | cut -d '"' -f 4)
+            TAG=$(echo $latest_release_url | cut -d '"' -f 2 | awk -F "/" '{print $NF}')
+            TAG_WO_VER=$(echo "${TAG}" | cut -c 2-)
+        fi
+    else
+        TAG=$DESIRED_VERSION
+        TAG_WO_VER=$(echo "${TAG}" | cut -c 2-)
+    fi
+}
+
+# checkGnmicInstalledVersion checks which version of gnmic is installed and
+# if it needs to be changed.
+checkGnmicInstalledVersion() {
+    if [[ -f "${GNMIC_INSTALL_DIR}/${BINARY_NAME}" ]]; then
+        local version=$("${GNMIC_INSTALL_DIR}/${BINARY_NAME}" version | head -1 | awk '{print $NF}')
+        if [[ "v$version" == "$TAG" ]]; then
+            echo "gnmic is already ${DESIRED_VERSION:-latest}"
+            return 0
+        else
+            echo "gnmic ${TAG_WO_VER} is available. Changing from version ${version}."
+            return 1
+        fi
+    else
+        return 1
+    fi
+}
+
+# downloadFile downloads the latest binary package and also the checksum
+# for that binary.
+downloadFile() {
+    GNMIC_DIST="${BINARY_NAME}_${TAG_WO_VER}_${OS}_${ARCH}.tar.gz"
+    DOWNLOAD_URL="https://github.com/karimra/gnmic/releases/download/${TAG}/${GNMIC_DIST}"
+    CHECKSUM_URL="https://github.com/karimra/gnmic/releases/download/${TAG}/checksums.txt"
+    GNMIC_TMP_ROOT="$(mktemp -d)"
+    GNMIC_TMP_FILE="$GNMIC_TMP_ROOT/$GNMIC_DIST"
+    GNMIC_SUM_FILE="$GNMIC_TMP_ROOT/checksums.txt"
+    echo "Downloading $DOWNLOAD_URL"
+    if type "curl" &>/dev/null; then
+        curl -SsL "$CHECKSUM_URL" -o "$GNMIC_SUM_FILE"
+    elif type "wget" &>/dev/null; then
+        wget -q -O "$GNMIC_SUM_FILE" "$CHECKSUM_URL"
+    fi
+    if type "curl" &>/dev/null; then
+        curl -SsL "$DOWNLOAD_URL" -o "$GNMIC_TMP_FILE"
+    elif type "wget" &>/dev/null; then
+        wget -q -O "$GNMIC_TMP_FILE" "$DOWNLOAD_URL"
+    fi
+}
+
+# installFile verifies the SHA256 for the file, then unpacks and
+# installs it.
+installFile() {
+    GNMIC_TMP="$GNMIC_TMP_ROOT/$BINARY_NAME"
+    if [ $VERIFY_CHECKSUM == "true" ]; then
+        local sum=$(openssl sha1 -sha256 ${GNMIC_TMP_FILE} | awk '{print $2}')
+        local expected_sum=$(cat ${GNMIC_SUM_FILE} | grep -i $GNMIC_DIST | awk '{print $1}')
+        if [ "$sum" != "$expected_sum" ]; then
+            echo "SHA sum of ${GNMIC_TMP_FILE} does not match. Aborting."
+            exit 1
+        fi
+    fi
+
+    mkdir -p "$GNMIC_TMP"
+    tar xf "$GNMIC_TMP_FILE" -C "$GNMIC_TMP"
+    GNMIC_TMP_BIN="$GNMIC_TMP/gnmic"
+    echo "Preparing to install $BINARY_NAME ${TAG_WO_VER} into ${GNMIC_INSTALL_DIR}"
+    runAsRoot cp "$GNMIC_TMP_BIN" "$GNMIC_INSTALL_DIR/$BINARY_NAME"
+    echo "$BINARY_NAME ${TAG_WO_VER} installed into $GNMIC_INSTALL_DIR/$BINARY_NAME"
+}
+
+# fail_trap is executed if an error occurs.
+fail_trap() {
+    result=$?
+    if [ "$result" != "0" ]; then
+        if [[ -n "$INPUT_ARGUMENTS" ]]; then
+            echo "Failed to install $BINARY_NAME with the arguments provided: $INPUT_ARGUMENTS"
+            help
+        else
+            echo "Failed to install $BINARY_NAME"
+        fi
+        echo -e "\tFor support, go to https://github.com/karimra/gnmic"
+    fi
+    cleanup
+    exit $result
+}
+
+# testVersion tests the installed client to make sure it is working.
+testVersion() {
+    set +e
+    HELM="$(command -v $BINARY_NAME)"
+    if [ "$?" = "1" ]; then
+        echo "$BINARY_NAME not found. Is $GNMIC_INSTALL_DIR on your "'$PATH?'
+        exit 1
+    fi
+    set -e
+}
+
+# help provides possible cli installation arguments
+help() {
+    echo "Accepted cli arguments are:"
+    echo -e "\t[--help|-h ] ->> prints this help"
+    echo -e "\t[--version|-v <desired_version>] . When not defined it fetches the latest release from GitHub"
+    echo -e "\te.g. --version v0.1.1"
+    echo -e "\t[--no-sudo]  ->> install without sudo"
+    echo -e "\t[--skip-checksum]  ->> disable automatic checksum verification"
+}
+
+cleanup() {
+    if [[ -d "${GNMIC_TMP_ROOT:-}" ]]; then
+        rm -rf "$GNMIC_TMP_ROOT"
+    fi
+}
+
+# Execution
+
+#Stop execution on any error
+trap "fail_trap" EXIT
 set -e
-TAR_PREFIX=gnmic
-PLATFORM=$(uname)
-ARCH=$(uname -m)
-INSTALLED_VERSION=$(gnmic version 2>/dev/null | grep version | awk '{print $3}') || ""
-LATEST_URL=$(curl -s https://github.com/karimra/gnmic/releases/latest | cut -d '"' -f 2)
-LATEST_TAG=$(echo "${LATEST_URL: -6}")
-TAG_WO_VER=$(echo "${LATEST_URL: -6}" | cut -c 2-)
-if [ "$INSTALLED_VERSION" == "$TAG_WO_VER" ]; then
-    echo "You have the latest gnmic version installed: $INSTALLED_VERSION"
-    exit 0
+
+# Parsing input arguments (if any)
+export INPUT_ARGUMENTS="${@}"
+set -u
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    '--version' | -v)
+        shift
+        if [[ $# -ne 0 ]]; then
+            export DESIRED_VERSION="v${1}"
+        else
+            echo -e "Please provide the desired version. e.g. --version 0.1.1"
+            exit 0
+        fi
+        ;;
+    '--no-sudo')
+        USE_SUDO="false"
+        ;;
+    '--skip-checksum')
+        VERIFY_CHECKSUM="false"
+        ;;
+    '--help' | -h)
+        help
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+    esac
+    shift
+done
+set +u
+
+initArch
+initOS
+verifySupported
+verifyOpenssl
+setDesiredVersion
+if ! checkGnmicInstalledVersion; then
+    downloadFile
+    installFile
 fi
-FNAME="${TAR_PREFIX}_${TAG_WO_VER}_${PLATFORM}_${ARCH}.tar.gz"
-echo "Downloading $FNAME..."
-(cd /tmp && curl -ksLO https://github.com/karimra/gnmic/releases/download/"$LATEST_TAG"/"$FNAME" || (echo "Failed to download release!" && exit 1))
-(mkdir -p /tmp/gnmic && tar -xzf /tmp/${FNAME} -C /tmp/gnmic) || (echo "Failed to unarchive!" && exit 1)
-echo "Moving gnmic to /usr/local/bin"
-echo
-mv -f /tmp/gnmic/gnmic /usr/local/bin
-/usr/local/bin/gnmic version
-echo
-# clean up
-rm -rf /tmp/gnmic
-rm -f /tmp/$FNAME
-echo "Installation complete!"
+testVersion
+cleanup

--- a/install.sh
+++ b/install.sh
@@ -172,7 +172,7 @@ fail_trap() {
 # testVersion tests the installed client to make sure it is working.
 testVersion() {
     set +e
-    GNMIC="$($BINARY_NAME version)"
+    GNMIC="$($GNMIC_INSTALL_DIR/$BINARY_NAME version)"
     if [ "$?" = "1" ]; then
         echo "$BINARY_NAME not found. Is $GNMIC_INSTALL_DIR in your "'$PATH?'
         exit 1

--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,7 @@ verifySupported() {
 verifyOpenssl() {
     if [ $VERIFY_CHECKSUM == "true" ]; then
         if ! type "openssl" &>/dev/null; then
-            echo "openssl is not found. Either install openssl or provide '--skip-checksum' flag to the installer"
+            echo "openssl is not found. It is used to verify checksum of the downloaded archive.\nEither install openssl or provide '--skip-checksum' flag to the installer"
             exit 1
         fi
     fi


### PR DESCRIPTION
closes #99 

The new installer script brings the following benefits:

* its is now possible to specify which version to download: ex. `bash install.sh -v 0.1.0`
* installer can upgrade and downgrade and will not perform any actions if the installed version matches the desired one
* installer now performs sha cheksum verification with `openssl`. This step can be skipped if `--skip-checksum` flag is provided to the installer
* supported both curl and wget based downloaders

To test the new installer use:
```bash
# download the latest published release
sudo curl -sL https://raw.githubusercontent.com/karimra/gnmic/new-installer/install.sh | sudo bash

# download the specific 0.1.0 version
sudo curl -sL https://raw.githubusercontent.com/karimra/gnmic/new-installer/install.sh | sudo bash -s -- -v 0.1.0

# download the specific 0.1.0 version and skip checksum verification
sudo curl -sL https://raw.githubusercontent.com/karimra/gnmic/new-installer/install.sh | sudo bash -s -- -v 0.1.0 --skip-checksum
```

I've tested this on OS X and Alpine/Ubuntu linux, still would be good for you to check