### PR TITLE
added disable method for qos marking in subscriptions

### DIFF
--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -170,7 +170,7 @@ func init() {
 	subscribeCmd.Flags().StringP("prefix", "", "", "subscribe request prefix")
 	subscribeCmd.Flags().StringArrayVarP(&paths, "path", "", []string{}, "subscribe request paths")
 	//subscribeCmd.MarkFlagRequired("path")
-	subscribeCmd.Flags().Int32P("qos", "q", 0, "qos marking")
+	subscribeCmd.Flags().Uint32P("qos", "q", 0, "qos marking")
 	subscribeCmd.Flags().BoolP("updates-only", "", false, "only updates to current state should be sent")
 	subscribeCmd.Flags().StringP("mode", "", "stream", "one of: once, stream, poll")
 	subscribeCmd.Flags().StringP("stream-mode", "", "target-defined", "one of: on-change, sample, target-defined")

--- a/collector/subscription.go
+++ b/collector/subscription.go
@@ -13,7 +13,6 @@ const (
 	subscriptionDefaultMode       = "STREAM"
 	subscriptionDefaultStreamMode = "TARGET_DEFINED"
 	subscriptionDefaultEncoding   = "JSON"
-	subscriptionDefaultQos        = 20
 )
 
 // SubscriptionConfig //
@@ -55,10 +54,6 @@ func (sc *SubscriptionConfig) setDefaults() error {
 	if sc.Encoding == "" {
 		sc.Encoding = subscriptionDefaultEncoding
 	}
-	if sc.Qos == nil {
-		sc.Qos = new(uint32)
-		*sc.Qos = subscriptionDefaultQos
-	}
 	return nil
 }
 
@@ -79,7 +74,10 @@ func (sc *SubscriptionConfig) CreateSubscribeRequest() (*gnmi.SubscribeRequest, 
 	if !ok {
 		return nil, fmt.Errorf("subscription '%s' invalid subscription list type '%s'", sc.Name, sc.Mode)
 	}
-	qos := &gnmi.QOSMarking{Marking: *sc.Qos}
+	var qos *gnmi.QOSMarking
+	if sc.Qos != nil {
+		qos = &gnmi.QOSMarking{Marking: *sc.Qos}
+	}
 
 	subscriptions := make([]*gnmi.Subscription, len(sc.Paths))
 	for i, p := range sc.Paths {


### PR DESCRIPTION
if no `--qos dd` flag is present on the CLI or no values are set via files, then the QOS structure won't be created in the subscription request.

That change was needed to support targets which can't handle qos markings even if they are set to 0.