### PR TITLE
change set --update-path and --replace-path annotations

### DIFF
--- a/cmd/set.go
+++ b/cmd/set.go
@@ -62,10 +62,10 @@ var setCmd = &cobra.Command{
 		"--prefix":       "XPATH",
 		"--replace":      "XPATH",
 		"--replace-file": "FILE",
-		"--replace-path": "PATH",
+		"--replace-path": "XPATH",
 		"--update":       "XPATH",
 		"--update-file":  "FILE",
-		"--update-path":  "PATH",
+		"--update-path":  "XPATH",
 	},
 
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
This PR changes the annotations of --update-path and --replace-path flags to XPATH  (from PATH) to get path auto completion.