### PR TITLE
Prometheus output

### DIFF
--- a/collector/event.go
+++ b/collector/event.go
@@ -111,7 +111,14 @@ func TagsFromGNMIPath(p *gnmi.Path) (string, map[string]string) {
 		}
 		if e.Key != nil {
 			for k, v := range e.Key {
-				tags[k] = v
+				if e.Name != "" {
+					elems := strings.Split(e.Name, ":")
+					if len(elems) > 0 {
+						tags[elems[len(elems)-1]+"_"+k] = v
+					}
+				} else {
+					tags[k] = v
+				}
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802
 	github.com/openconfig/goyang v0.0.0-20200908203031-af27d3788542
 	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/gnxi v0.0.0-20200508145201-92c6d0d3ec3b
 	github.com/google/uuid v1.1.1
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/influxdata/influxdb-client-go v1.4.0
 	github.com/influxdata/influxdb-client-go/v2 v2.0.1
 	github.com/karimra/go-map-flattener v0.0.0-20200728034653-b1473e58dae8
 	github.com/karimra/sros-dialout v0.0.0-20200518085040-c759bf74063a

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea/go.mod h1:pN
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/influxdata/influxdb-client-go v1.4.0 h1:+KavOkwhLClHFfYcJMHHnTL5CZQhXJzOm5IKHI9BqJk=
+github.com/influxdata/influxdb-client-go v1.4.0/go.mod h1:S+oZsPivqbcP1S9ur+T+QqXvrYS3NCZeMQtBoH4D1dw=
 github.com/influxdata/influxdb-client-go/v2 v2.0.1 h1:vRla3taM+zkziP1NUGfN6Y6zJ9ZSSMg0fs/JhCGyX1s=
 github.com/influxdata/influxdb-client-go/v2 v2.0.1/go.mod h1:eyFPc0lhFnNSpyCDb0ZkrB3Hbtqvn1K1JZmjo2BXqeo=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=

--- a/outputs/all/all.go
+++ b/outputs/all/all.go
@@ -2,10 +2,11 @@ package all
 
 import (
 	_ "github.com/karimra/gnmic/outputs/file"
+	_ "github.com/karimra/gnmic/outputs/influxdb_output"
 	_ "github.com/karimra/gnmic/outputs/kafka_output"
 	_ "github.com/karimra/gnmic/outputs/nats_output"
+	_ "github.com/karimra/gnmic/outputs/prometheus_output"
 	_ "github.com/karimra/gnmic/outputs/stan_output"
 	_ "github.com/karimra/gnmic/outputs/tcp_output"
 	_ "github.com/karimra/gnmic/outputs/udp_output"
-	_ "github.com/karimra/gnmic/outputs/influxdb_output"
 )

--- a/outputs/prometheus_output/prometheus_output.go
+++ b/outputs/prometheus_output/prometheus_output.go
@@ -3,24 +3,36 @@ package prometheus_output
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"hash/fnv"
 	"log"
+	"math"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/karimra/gnmic/collector"
 	"github.com/karimra/gnmic/outputs"
 	"github.com/mitchellh/mapstructure"
+	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
 )
 
 const (
-	defaultListen     = ":9273"
+	defaultListen     = ":9804"
 	defaultPath       = "/metrics"
 	defaultExpiration = time.Minute
+	defaultMetricHelp = "gNMIc generated metric"
 )
 
 type labelPair struct {
@@ -29,7 +41,7 @@ type labelPair struct {
 }
 type promMetric struct {
 	name   string
-	labels []labelPair
+	labels []*labelPair
 	time   time.Time
 	value  float64
 }
@@ -39,6 +51,7 @@ func init() {
 		return &PrometheusOutput{
 			Cfg:       &Config{},
 			eventChan: make(chan *collector.EventMsg),
+			entries:   make(map[uint64]*promMetric),
 		}
 	})
 }
@@ -50,14 +63,17 @@ type PrometheusOutput struct {
 	cancelFn  context.CancelFunc
 	eventChan chan *collector.EventMsg
 
+	server *http.Server
 	sync.Mutex
 	entries map[uint64]*promMetric
+
+	replacer *strings.Replacer
 }
 type Config struct {
-	Listen        string
-	Path          string
-	Expiration    time.Duration
-	StringAslabel bool
+	Listen     string        `mapstructure:"listen,omitempty"`
+	Path       string        `mapstructure:"path,omitempty"`
+	Expiration time.Duration `mapstructure:"expiration,omitempty"`
+	Debug      bool          `mapstructure:"debug,omitempty"`
 }
 
 func (p *PrometheusOutput) String() string {
@@ -69,7 +85,16 @@ func (p *PrometheusOutput) String() string {
 }
 func (p *PrometheusOutput) Init(ctx context.Context, cfg map[string]interface{}, logger *log.Logger) error {
 	ctx, p.cancelFn = context.WithCancel(ctx)
-	err := mapstructure.Decode(cfg, p.Cfg)
+	decoder, err := mapstructure.NewDecoder(
+		&mapstructure.DecoderConfig{
+			DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
+			Result:     p.Cfg,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	err = decoder.Decode(cfg)
 	if err != nil {
 		return err
 	}
@@ -87,41 +112,244 @@ func (p *PrometheusOutput) Init(ctx context.Context, cfg map[string]interface{},
 		p.logger.SetOutput(logger.Writer())
 		p.logger.SetFlags(logger.Flags())
 	}
+	p.replacer = strings.NewReplacer("-", "_", ":", "_", "/", "_")
+	// create prometheus registery
+	registry := prometheus.NewRegistry()
+
+	err = registry.Register(p)
+	if err != nil {
+		return err
+	}
+	// create http server
+	promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError})
+
+	mux := http.NewServeMux()
+	mux.Handle(p.Cfg.Path, promHandler)
+
+	p.server = &http.Server{
+		Addr:    p.Cfg.Listen,
+		Handler: mux,
+	}
+
+	// create tcp listener
+	listener, err := net.Listen("tcp", p.Cfg.Listen)
+	if err != nil {
+		return err
+	}
+	// start worker
+	go p.worker(ctx)
+	go func() {
+		err = p.server.Serve(listener)
+		if err != nil && err != http.ErrServerClosed {
+			p.logger.Printf("prometheus server error: %v", err)
+		}
+	}()
+	p.logger.Printf("initialized prometheus output: %s", p.String())
 	return nil
 }
-func (p *PrometheusOutput) Write(ctx context.Context, rsp proto.Message, meta outputs.Meta) {}
-func (p *PrometheusOutput) Close() error                                                    { return nil }
-func (p *PrometheusOutput) Metrics() []prometheus.Collector                                 { return p.metrics }
+func (p *PrometheusOutput) Write(ctx context.Context, rsp proto.Message, meta outputs.Meta) {
+	if rsp == nil {
+		return
+	}
+	switch rsp := rsp.(type) {
+	case *gnmi.SubscribeResponse:
+		measName := "default"
+		if subName, ok := meta["subscription-name"]; ok {
+			measName = subName
+		}
+		events, err := collector.ResponseToEventMsgs(measName, rsp, meta)
+		if err != nil {
+			p.logger.Printf("failed to convert message to event: %v", err)
+			return
+		}
+		for _, ev := range events {
+			select {
+			case <-ctx.Done():
+				return
+			case p.eventChan <- ev:
+			}
+		}
+	}
+}
+func (p *PrometheusOutput) Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	p.server.Shutdown(ctx)
+	p.cancelFn()
+	return nil
+}
+func (p *PrometheusOutput) Metrics() []prometheus.Collector { return p.metrics }
 
 ///
 func (p *PrometheusOutput) Describe(ch chan<- *prometheus.Desc) {}
+
 func (p *PrometheusOutput) Collect(ch chan<- prometheus.Metric) {
+	p.Lock()
+	defer p.Unlock()
+
+	for _, entry := range p.entries {
+		ch <- entry
+	}
 }
 
-func (p *PrometheusOutput) getLabels(ev *collector.EventMsg) []labelPair {
-	labels := make([]labelPair, 0, len(ev.Tags))
+func (p *PrometheusOutput) getLabels(ev *collector.EventMsg) []*labelPair {
+	labels := make([]*labelPair, 0, len(ev.Tags))
+	addedLabels := make(map[string]struct{})
 	for k, v := range ev.Tags {
-		labels = append(labels, labelPair{Name: filepath.Base(k), Value: v})
-	}
-	if p.Cfg.StringAslabel {
-		for k, v := range ev.Values {
-			switch v := v.(type) {
-			case string:
-				labels = append(labels, labelPair{Name: filepath.Base(k), Value: v})
-			}
+		labelName := p.replacer.Replace(filepath.Base(k))
+		if _, ok := addedLabels[labelName]; ok {
+			continue
 		}
+		labels = append(labels, &labelPair{Name: labelName, Value: v})
+		addedLabels[labelName] = struct{}{}
 	}
 	return labels
 }
 
+func (p *PrometheusOutput) worker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev := <-p.eventChan:
+			if p.Cfg.Debug {
+				p.logger.Printf("got event to store: %+v", ev)
+			}
+			p.Lock()
+			labels := p.getLabels(ev)
+			for vName, val := range ev.Values {
+				v, err := getFloat(val)
+				if err != nil {
+					continue
+				}
+				metricName := strings.TrimRight(p.replacer.Replace(ev.Name), "_")
+				metricName += "_" + strings.TrimLeft(p.replacer.Replace(vName), "_")
+				pm := &promMetric{
+					name:   metricName,
+					labels: labels,
+					time:   time.Unix(0, ev.Timestamp),
+					value:  v,
+				}
+				key := pm.calculateKey()
+				if e, ok := p.entries[key]; ok {
+					if e.time.Before(pm.time) {
+						p.entries[key] = pm
+					}
+				} else {
+					p.entries[key] = pm
+				}
+				if p.Cfg.Debug {
+					p.logger.Printf("saved key=%d, metric: %+v", key, pm)
+				}
+			}
+			// expire entries
+			expiry := time.Now().Add(-p.Cfg.Expiration)
+			for k, e := range p.entries {
+				if e.time.Before(expiry) {
+					delete(p.entries, k)
+				}
+			}
+			p.Unlock()
+		}
+	}
+}
+
+// Metric
 func (p *promMetric) calculateKey() uint64 {
 	h := fnv.New64a()
 	h.Write([]byte(p.name))
-	for _, label := range p.labels {
-		h.Write([]byte(label.Name))
+	if len(p.labels) > 0 {
 		h.Write([]byte(":"))
-		h.Write([]byte(label.Value))
-		h.Write([]byte(":"))
+		sort.Slice(p.labels, func(i, j int) bool {
+			return p.labels[i].Name < p.labels[j].Name
+		})
+		for _, label := range p.labels {
+			h.Write([]byte(label.Name))
+			h.Write([]byte(":"))
+			h.Write([]byte(label.Value))
+			h.Write([]byte(":"))
+		}
 	}
 	return h.Sum64()
+}
+func (p *promMetric) String() string {
+	if p == nil {
+		return ""
+	}
+	sb := strings.Builder{}
+	sb.WriteString("name=")
+	sb.WriteString(p.name)
+	sb.WriteString(",")
+	if len(p.labels) > 0 {
+		sb.WriteString("[")
+		for _, lb := range p.labels {
+			sb.WriteString("[")
+			sb.WriteString(lb.Name)
+			sb.WriteString("=")
+			sb.WriteString(lb.Value)
+			sb.WriteString(",")
+		}
+		sb.WriteString("]")
+	}
+	sb.WriteString(fmt.Sprintf("value=%f,", p.value))
+	sb.WriteString("time=")
+	sb.WriteString(p.time.String())
+	return sb.String()
+}
+func (p *promMetric) Desc() *prometheus.Desc {
+	labelNames := make([]string, 0, len(p.labels))
+	for _, label := range p.labels {
+		labelNames = append(labelNames, label.Name)
+	}
+
+	return prometheus.NewDesc(p.name, defaultMetricHelp, labelNames, nil)
+}
+func (p *promMetric) Write(out *dto.Metric) error {
+	out.Untyped = &dto.Untyped{
+		Value: &p.value,
+	}
+	out.Label = make([]*dto.LabelPair, 0, len(p.labels))
+	for _, lb := range p.labels {
+		out.Label = append(out.Label, &dto.LabelPair{Name: &lb.Name, Value: &lb.Value})
+	}
+	timestamp := p.time.UnixNano() / 1000
+	out.TimestampMs = &timestamp
+	return nil
+}
+
+func getFloat(v interface{}) (float64, error) {
+	switch i := v.(type) {
+	case float64:
+		return float64(i), nil
+	case float32:
+		return float64(i), nil
+	case int64:
+		return float64(i), nil
+	case int32:
+		return float64(i), nil
+	case int16:
+		return float64(i), nil
+	case int8:
+		return float64(i), nil
+	case uint64:
+		return float64(i), nil
+	case uint32:
+		return float64(i), nil
+	case uint16:
+		return float64(i), nil
+	case uint8:
+		return float64(i), nil
+	case int:
+		return float64(i), nil
+	case uint:
+		return float64(i), nil
+	case string:
+		f, err := strconv.ParseFloat(i, 64)
+		if err != nil {
+			return math.NaN(), err
+		}
+		return f, err
+	default:
+		return math.NaN(), errors.New("getFloat: unknown value is of incompatible type")
+	}
 }

--- a/outputs/prometheus_output/prometheus_output.go
+++ b/outputs/prometheus_output/prometheus_output.go
@@ -289,16 +289,18 @@ func (p *promMetric) String() string {
 	sb.WriteString("name=")
 	sb.WriteString(p.name)
 	sb.WriteString(",")
-	if len(p.labels) > 0 {
-		sb.WriteString("[")
-		for _, lb := range p.labels {
-			sb.WriteString("[")
+	numLabels := len(p.labels)
+	if numLabels > 0 {
+		sb.WriteString("labels=[")
+		for i, lb := range p.labels {
 			sb.WriteString(lb.Name)
 			sb.WriteString("=")
 			sb.WriteString(lb.Value)
-			sb.WriteString(",")
+			if i < numLabels-1 {
+				sb.WriteString(",")
+			}
 		}
-		sb.WriteString("]")
+		sb.WriteString("],")
 	}
 	sb.WriteString(fmt.Sprintf("value=%f,", p.value))
 	sb.WriteString("time=")

--- a/outputs/prometheus_output/prometheus_output.go
+++ b/outputs/prometheus_output/prometheus_output.go
@@ -1,0 +1,110 @@
+package prometheus_output
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/karimra/gnmic/collector"
+	"github.com/karimra/gnmic/outputs"
+	"github.com/mitchellh/mapstructure"
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	defaultListen     = ":9273"
+	defaultPath       = "/metrics"
+	defaultExpiration = time.Minute
+)
+
+type labelPair struct {
+	Name  string
+	Value string
+}
+type promMetric struct {
+	
+}
+func init() {
+	outputs.Register("prometheus", func() outputs.Output {
+		return &PrometheusOutput{
+			Cfg:       &Config{},
+			eventChan: make(chan *collector.EventMsg),
+		}
+	})
+}
+
+type PrometheusOutput struct {
+	Cfg       *Config
+	metrics   []prometheus.Collector
+	logger    *log.Logger
+	cancelFn  context.CancelFunc
+	eventChan chan *collector.EventMsg
+
+	sync.Mutex
+	entries map[uint64]interface{}
+}
+type Config struct {
+	Listen        string
+	Path          string
+	Expiration    time.Duration
+	StringAslabel bool
+}
+
+func (p *PrometheusOutput) String() string {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+func (p *PrometheusOutput) Init(ctx context.Context, cfg map[string]interface{}, logger *log.Logger) error {
+	ctx, p.cancelFn = context.WithCancel(ctx)
+	err := mapstructure.Decode(cfg, p.Cfg)
+	if err != nil {
+		return err
+	}
+	if p.Cfg.Listen == "" {
+		p.Cfg.Listen = defaultListen
+	}
+	if p.Cfg.Path == "" {
+		p.Cfg.Path = defaultPath
+	}
+	if p.Cfg.Expiration == 0 {
+		p.Cfg.Expiration = defaultExpiration
+	}
+	p.logger = log.New(os.Stderr, "prometheus_output ", log.LstdFlags|log.Lmicroseconds)
+	if logger != nil {
+		p.logger.SetOutput(logger.Writer())
+		p.logger.SetFlags(logger.Flags())
+	}
+	return nil
+}
+func (p *PrometheusOutput) Write(ctx context.Context, rsp proto.Message, meta outputs.Meta) {}
+func (p *PrometheusOutput) Close() error                                                    { return nil }
+func (p *PrometheusOutput) Metrics() []prometheus.Collector                                 { return p.metrics }
+
+///
+func (p *PrometheusOutput) Describe(ch chan<- *prometheus.Desc) {}
+func (p *PrometheusOutput) Collect(ch chan<- prometheus.Metric) {
+}
+
+func (p *PrometheusOutput) getLabels(ev *collector.EventMsg) []labelPair {
+	labels := make([]labelPair, 0, len(ev.Tags))
+	for k, v := range ev.Tags {
+		labels = append(labels, labelPair{Name: filepath.Base(k), Value: v})
+	}
+	if p.Cfg.StringAslabel {
+		for k, v := range ev.Values {
+			switch v := v.(type) {
+			case string:
+				labels = append(labels, labelPair{Name: filepath.Base(k), Value: v})
+			}
+		}
+	}
+	return labels
+}

--- a/outputs/prometheus_output/prometheus_output.go
+++ b/outputs/prometheus_output/prometheus_output.go
@@ -312,7 +312,7 @@ func (p *promMetric) Write(out *dto.Metric) error {
 	for _, lb := range p.labels {
 		out.Label = append(out.Label, &dto.LabelPair{Name: &lb.Name, Value: &lb.Value})
 	}
-	timestamp := p.time.UnixNano() / 1000
+	timestamp := p.time.UnixNano() / 1000000
 	out.TimestampMs = &timestamp
 	return nil
 }

--- a/outputs/prometheus_output/prometheus_output.go
+++ b/outputs/prometheus_output/prometheus_output.go
@@ -231,10 +231,8 @@ func (p *PrometheusOutput) worker(ctx context.Context) {
 				if err != nil {
 					continue
 				}
-				metricName := strings.TrimRight(p.replacer.Replace(ev.Name), "_")
-				metricName += "_" + strings.TrimLeft(p.replacer.Replace(vName), "_")
 				pm := &promMetric{
-					name:   metricName,
+					name:   p.metricName(ev.Name, vName),
 					labels: labels,
 					time:   time.Unix(0, ev.Timestamp),
 					value:  v,
@@ -363,4 +361,12 @@ func getFloat(v interface{}) (float64, error) {
 	default:
 		return math.NaN(), errors.New("getFloat: unknown value is of incompatible type")
 	}
+}
+
+func (p *PrometheusOutput) metricName(measName, valueName string) string {
+	sb := strings.Builder{}
+	sb.WriteString(strings.TrimRight(p.replacer.Replace(measName), "_"))
+	sb.WriteString("_")
+	sb.WriteString(strings.TrimLeft(p.replacer.Replace(valueName), "_"))
+	return sb.String()
 }


### PR DESCRIPTION
This PR adds support for prometheus client output.
gnmic starts an http server and makes the created subscriptions data available to be scraped by a prometheus client
Sample configuration:
```
outputs:
  group1:
    - type: prometheus
      listen: ":9804"
      path: "/metrics" 
      expiration: 10s
      debug: true
```