### PR TITLE
Added the prefix and path correlated auto completion

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -42,7 +42,7 @@ var getCmd = &cobra.Command{
 	Short: "run gnmi get on targets",
 	Annotations: map[string]string{
 		"--path":   "XPATH",
-		"--prefix": "XPATH",
+		"--prefix": "PREFIX",
 		"--model":  "MODEL",
 		"--type":   "STORE",
 	},

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -495,7 +495,6 @@ func (co cmdPrompt) Run() {
 			promptArgs := strings.Fields(in)
 			os.Args = append([]string{os.Args[0]}, promptArgs...)
 			if len(promptArgs) > 0 {
-				co.RootCmd.Execute()
 				err := co.RootCmd.Execute()
 				if err == nil && in != "" {
 					promptHistory = append(promptHistory, in)

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -307,7 +307,6 @@ func findDynamicSuggestions(annotation string, doc goprompt.Document) []goprompt
 		line := doc.CurrentLine()
 		word := doc.GetWordBeforeCursor()
 		suggestions := make([]goprompt.Suggest, 0, 16)
-		// if prefixPath != nil && *prefixPath != "" {
 		entries := []*yang.Entry{}
 		if index := strings.Index(line, "--prefix"); index >= 0 {
 			line = strings.TrimLeft(line[index+len("--prefix"):], " ")

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -216,6 +216,68 @@ func findMatchedXPATH(entry *yang.Entry, word string, cursor int) []goprompt.Sug
 	return suggestions
 }
 
+func findMatchedSchema(entry *yang.Entry, word string, cursor int) []*yang.Entry {
+	schemaNodes := []*yang.Entry{}
+	cword := word[cursor:]
+	for name, child := range entry.Dir {
+		pathelem := "/" + name
+		if strings.HasPrefix(pathelem, cword) {
+			node := ""
+			if os.PathSeparator != '/' {
+				node = fmt.Sprintf("%s%s", word[:cursor], pathelem)
+				schemaNodes = append(schemaNodes, child)
+			} else {
+				if len(cword) >= 1 && cword[0] == '/' {
+					node = name
+				} else {
+					node = pathelem
+				}
+				schemaNodes = append(schemaNodes, child)
+			}
+			if child.Key != "" { // list
+				keylist := strings.Split(child.Key, " ")
+				for _, key := range keylist {
+					node = fmt.Sprintf("%s[%s=*]", node, key)
+				}
+				schemaNodes = append(schemaNodes, child)
+			}
+		} else if strings.HasPrefix(cword, pathelem) {
+			var prevC rune
+			var bracketCount int
+			var endIndex int = -1
+			var stop bool
+			for i, c := range cword {
+				switch c {
+				case '[':
+					bracketCount++
+				case ']':
+					if prevC != '\\' {
+						bracketCount--
+						endIndex = i
+					}
+				case '/':
+					if i != 0 && bracketCount == 0 {
+						endIndex = i
+						stop = true
+					}
+				}
+				if stop {
+					break
+				}
+				prevC = c
+			}
+			if bracketCount == 0 {
+				if endIndex >= 0 {
+					schemaNodes = append(schemaNodes, findMatchedSchema(child, word, cursor+endIndex)...)
+				} else {
+					schemaNodes = append(schemaNodes, findMatchedSchema(child, word, cursor+len(pathelem))...)
+				}
+			}
+		}
+	}
+	return schemaNodes
+}
+
 var filePathCompleter = completer.FilePathCompleter{
 	IgnoreCase: true,
 	Filter: func(fi os.FileInfo) bool {
@@ -242,6 +304,29 @@ var dirPathCompleter = completer.FilePathCompleter{
 func findDynamicSuggestions(annotation string, doc goprompt.Document) []goprompt.Suggest {
 	switch annotation {
 	case "XPATH":
+		line := doc.CurrentLine()
+		word := doc.GetWordBeforeCursor()
+		suggestions := make([]goprompt.Suggest, 0, 16)
+		// if prefixPath != nil && *prefixPath != "" {
+		entries := []*yang.Entry{}
+		if index := strings.Index(line, "--prefix"); index >= 0 {
+			line = strings.TrimLeft(line[index+len("--prefix"):], " ")
+			end := strings.Index(line, " ")
+			if end >= 0 {
+				for _, entry := range schemaTree.Dir {
+					entries = append(entries, findMatchedSchema(entry, line[:end], 0)...)
+				}
+				for _, entry := range entries {
+					suggestions = append(suggestions, findMatchedXPATH(entry, word, 0)...)
+				}
+			}
+		} else {
+			for _, entry := range schemaTree.Dir {
+				suggestions = append(suggestions, findMatchedXPATH(entry, word, 0)...)
+			}
+		}
+		return suggestions
+	case "PREFIX":
 		word := doc.GetWordBeforeCursor()
 		suggestions := make([]goprompt.Suggest, 0, 16)
 		for _, entry := range schemaTree.Dir {
@@ -411,6 +496,7 @@ func (co cmdPrompt) Run() {
 			promptArgs := strings.Fields(in)
 			os.Args = append([]string{os.Args[0]}, promptArgs...)
 			if len(promptArgs) > 0 {
+				co.RootCmd.Execute()
 				err := co.RootCmd.Execute()
 				if err == nil && in != "" {
 					promptHistory = append(promptHistory, in)

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -59,7 +59,7 @@ var setCmd = &cobra.Command{
 	Short: "run gnmi set on targets",
 	Annotations: map[string]string{
 		"--delete":       "XPATH",
-		"--prefix":       "XPATH",
+		"--prefix":       "PREFIX",
 		"--replace":      "XPATH",
 		"--replace-file": "FILE",
 		"--replace-path": "XPATH",

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -54,7 +54,7 @@ var subscribeCmd = &cobra.Command{
 	Short:   "subscribe to gnmi updates on targets",
 	Annotations: map[string]string{
 		"--path":        "XPATH",
-		"--prefix":      "XPATH",
+		"--prefix":      "PREFIX",
 		"--model":       "MODEL",
 		"--mode":        "SUBSC_MODE",
 		"--stream-mode": "STREAM_MODE",


### PR DESCRIPTION
This PR enables the data path is suggested continuously according to the --prefix path in the auto completion.
Please add it for combined --prefix and --path auto-completion.

```bash
gnmic> get --prefix /interfaces --path /interface/name
```

Thanks.
neoul