### PR TITLE
add YANG info to xpath suggestion description

### DIFF
--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -219,10 +219,15 @@ func findMatchedXPATH(entry *yang.Entry, word string, cursor int) []goprompt.Sug
 
 func buildXPATHDescription(entry *yang.Entry) string {
 	sb := strings.Builder{}
-	if entry.Dir != nil {
-		sb.WriteString("[+] ")
-	} else {
+	switch {
+	case entry.Dir == nil && entry.ListAttr != nil: // leaf-list
+		sb.WriteString("[⋯] ")
+	case entry.Dir == nil: // leaf
 		sb.WriteString("    ")
+	case entry.ListAttr != nil: // list
+		sb.WriteString("[+] ")
+	default: // container
+		sb.WriteString("[+] ")
 	}
 	sb.WriteString(getPermissions(entry))
 	sb.WriteString(" ")

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -145,6 +145,7 @@ func initPromptFlags(cmd *cobra.Command) {
 	cmd.Flags().String("suggestions-bg-color", "dark_blue", "suggestion box background color")
 	cmd.Flags().String("description-bg-color", "dark_gray", "description box background color")
 	cmd.Flags().Bool("suggest-all-flags", false, "suggest local as well as inherited flags of subcommands")
+	cmd.Flags().Bool("description-with-prefix", false, "show YANG module prefix in XPATH suggestion description")
 	viper.BindPFlag("prompt-file", cmd.LocalFlags().Lookup("file"))
 	viper.BindPFlag("prompt-exclude", cmd.LocalFlags().Lookup("exclude"))
 	viper.BindPFlag("prompt-dir", cmd.LocalFlags().Lookup("dir"))
@@ -153,6 +154,7 @@ func initPromptFlags(cmd *cobra.Command) {
 	viper.BindPFlag("prompt-suggestions-bg-color", cmd.LocalFlags().Lookup("suggestions-bg-color"))
 	viper.BindPFlag("prompt-description-bg-color", cmd.LocalFlags().Lookup("description-bg-color"))
 	viper.BindPFlag("prompt-suggest-all-flags", cmd.LocalFlags().Lookup("suggest-all-flags"))
+	viper.BindPFlag("prompt-description-with-prefix", cmd.LocalFlags().Lookup("description-with-prefix"))
 }
 
 func findMatchedXPATH(entry *yang.Entry, word string, cursor int) []goprompt.Suggest {
@@ -231,6 +233,12 @@ func buildXPATHDescription(entry *yang.Entry) string {
 	}
 	sb.WriteString(getPermissions(entry))
 	sb.WriteString(" ")
+	if viper.GetBool("prompt-description-with-prefix") {
+		if entry.Prefix != nil {
+			sb.WriteString(entry.Prefix.Name)
+			sb.WriteString(": ")
+		}
+	}
 	sb.WriteString(entry.Description)
 	return sb.String()
 }


### PR DESCRIPTION
This PR enhances the suggested xpaths description with some data from the yang model.
- Indication of presence of child entries
- The yang entry permissions
- The yang entry type if `--description-with-types` if present
- The yang entry prefix if `--description-with-prefix` if present

![Screen Shot 2020-10-20 at 7 07 58 PM](https://user-images.githubusercontent.com/12892894/96578499-e30e5c00-1307-11eb-8659-b9589d4264b0.png)
