### PR TITLE
compare xpaths by description if the text field is equal

### DIFF
--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -359,6 +359,9 @@ func findDynamicSuggestions(annotation string, doc goprompt.Document) []goprompt
 			suggestions = append(suggestions, goprompt.Suggest{Text: name})
 		}
 		sort.Slice(suggestions, func(i, j int) bool {
+			if suggestions[i].Text == suggestions[j].Text {
+				return suggestions[i].Description < suggestions[j].Description
+			}
 			return suggestions[i].Text < suggestions[j].Text
 		})
 		return goprompt.FilterHasPrefix(suggestions, doc.GetWordBeforeCursor(), true)

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -326,6 +326,9 @@ func findDynamicSuggestions(annotation string, doc goprompt.Document) []goprompt
 			}
 		}
 		sort.Slice(suggestions, func(i, j int) bool {
+			if suggestions[i].Text == suggestions[j].Text {
+				return suggestions[i].Description < suggestions[j].Description
+			}
 			return suggestions[i].Text < suggestions[j].Text
 		})
 		return suggestions
@@ -336,6 +339,9 @@ func findDynamicSuggestions(annotation string, doc goprompt.Document) []goprompt
 			suggestions = append(suggestions, findMatchedXPATH(entry, word, 0)...)
 		}
 		sort.Slice(suggestions, func(i, j int) bool {
+			if suggestions[i].Text == suggestions[j].Text {
+				return suggestions[i].Description < suggestions[j].Description
+			}
 			return suggestions[i].Text < suggestions[j].Text
 		})
 		return suggestions


### PR DESCRIPTION
This PR fixes xpath suggestions shuffling in case there are equal xpath elements.
the issues from from the fact that the regeneration of the suggestions might produce a different order every-time.

This fixes it by comparing the description if the suggestion texts are equal.