### PR TITLE
Dynamic max suggestions

### DIFF
--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -62,6 +62,18 @@ func getColor(flagName string) goprompt.Color {
 var promptModeCmd = &cobra.Command{
 	Use:   "prompt",
 	Short: "enter the interactive gnmic prompt mode",
+	// PreRun checks is --max-suggesions is bigger that the terminal height and lowers it if it's the case.
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := termbox.Init(); err != nil {
+			return // silently continue cmd execution if termbox cannot be initialized
+		}
+		_, h := termbox.Size()
+		termbox.Close()
+		// set max suggestions to terminal height-1 if the supplied value is greater
+		if viper.GetUint("prompt-max-suggestions") > uint(h) {
+			viper.Set("prompt-max-suggestions", h-1)
+		}
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := generateYangSchema(promptDirs, promptFiles, promptExcluded)
 		if err != nil {

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -153,7 +153,7 @@ func initPromptFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVarP(&promptFiles, "file", "", []string{}, "path to a yang file or a directory of them to get path auto-completions from")
 	cmd.Flags().StringArrayVarP(&promptExcluded, "exclude", "", []string{}, "yang module names to be excluded from path auto-completion generation")
 	cmd.Flags().StringArrayVarP(&promptDirs, "dir", "", []string{}, "path to a directory with yang modules used as includes and/or imports")
-	cmd.Flags().Uint16("max-suggestions", 5, "terminal suggestion max list size")
+	cmd.Flags().Uint16("max-suggestions", 10, "terminal suggestion max list size")
 	cmd.Flags().String("prefix-color", "dark_blue", "terminal prefix color")
 	cmd.Flags().String("suggestions-bg-color", "dark_blue", "suggestion box background color")
 	cmd.Flags().String("description-bg-color", "dark_gray", "description box background color")

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -71,7 +71,11 @@ var promptModeCmd = &cobra.Command{
 		termbox.Close()
 		// set max suggestions to terminal height-1 if the supplied value is greater
 		if viper.GetUint("prompt-max-suggestions") > uint(h) {
-			viper.Set("prompt-max-suggestions", h-1)
+			if h > 1 {
+				viper.Set("prompt-max-suggestions", h-2)
+			} else {
+				viper.Set("prompt-max-suggestions", 0)
+			}
 		}
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -62,10 +62,10 @@ func getColor(flagName string) goprompt.Color {
 var promptModeCmd = &cobra.Command{
 	Use:   "prompt",
 	Short: "enter the interactive gnmic prompt mode",
-	// PreRun checks is --max-suggesions is bigger that the terminal height and lowers it if it's the case.
+	// PreRun checks if --max-suggesions is bigger that the terminal height and lowers it if needed.
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if err := termbox.Init(); err != nil {
-			return // silently continue cmd execution if termbox cannot be initialized
+			return // silently continue cmd execution if termbox fails to initialize
 		}
 		_, h := termbox.Size()
 		termbox.Close()

--- a/docs/cmd/prompt.md
+++ b/docs/cmd/prompt.md
@@ -40,7 +40,7 @@ Multiple `--exclude` flags can be supplied.
 #### max-suggestions
 The `--max-suggestions` flag sets the number of lines that the suggestion box will display without scrolling.
 
-Defaults to 10.
+Defaults to 10. Note, the terminal height might limit the number of lines in the suggestions box. 
 
 #### suggest-all-flags
 The `--suggest-all-flags` makes `gnmic` prompt suggest both global and local flags for a sub-command.


### PR DESCRIPTION
This PR add a PreRun func to prompt command, to check if the terminal height is smaller that the supplied --max-suggestions flag value.
if It's the case, it changes the --max-suggestions value to $(terminal_height -1)