### PR TITLE
Subscribe output

### DIFF
--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -499,6 +499,14 @@ func findDynamicSuggestions(annotation string, doc goprompt.Document) []goprompt
 			suggestions = append(suggestions, goprompt.Suggest{Text: target.Name, Description: sb.String()})
 		}
 		return goprompt.FilterHasPrefix(suggestions, doc.GetWordBeforeCursor(), true)
+	case "OUTPUT":
+		outputGroups := getOutputsFromCfg()
+		fmt.Println()
+		suggestions := make([]goprompt.Suggest, 0, len(outputGroups))
+		for _, sugg := range outputGroups {
+			suggestions = append(suggestions, goprompt.Suggest{Text: sugg.name, Description: strings.Join(sugg.types, ", ")})
+		}
+		return goprompt.FilterHasPrefix(suggestions, doc.GetWordBeforeCursor(), true)
 	}
 	return []goprompt.Suggest{}
 }

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -432,3 +432,33 @@ func readSubscriptionsFromCfg() []*collector.SubscriptionConfig {
 	})
 	return subscriptions
 }
+
+type outputSuggestion struct {
+	name  string
+	types []string
+}
+
+func getOutputsFromCfg() []outputSuggestion {
+	outDef := viper.GetStringMap("outputs")
+	suggestions := make([]outputSuggestion, 0, len(outDef))
+	for name, d := range outDef {
+		dl := convert(d)
+		sug := outputSuggestion{name: name, types: make([]string, 0)}
+		switch outs := dl.(type) {
+		case []interface{}:
+			for _, ou := range outs {
+				switch ou := ou.(type) {
+				case map[string]interface{}:
+					if outType, ok := ou["type"]; ok {
+						sug.types = append(sug.types, outType.(string))
+					}
+				}
+			}
+		}
+		suggestions = append(suggestions, sug)
+	}
+	sort.Slice(suggestions, func(i, j int) bool {
+		return suggestions[i].name < suggestions[j].name
+	})
+	return suggestions
+}

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -59,6 +59,7 @@ var subscribeCmd = &cobra.Command{
 		"--mode":        "SUBSC_MODE",
 		"--stream-mode": "STREAM_MODE",
 		"--name":        "SUBSCRIPTION",
+		"--output":      "OUTPUT",
 	},
 
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -226,6 +227,7 @@ func initSubscribeFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("quiet", false, "suppress stdout printing")
 	cmd.Flags().StringP("target", "", "", "subscribe request target")
 	cmd.Flags().StringSliceP("name", "n", []string{}, "reference subscriptions by name, must be defined in gnmic config file")
+	cmd.Flags().StringSliceP("output", "", []string{}, "reference to output groups by name, must be defined in gnmic config file")
 	//
 	viper.BindPFlag("subscribe-prefix", cmd.LocalFlags().Lookup("prefix"))
 	viper.BindPFlag("subscribe-path", cmd.LocalFlags().Lookup("path"))
@@ -240,6 +242,7 @@ func initSubscribeFlags(cmd *cobra.Command) {
 	viper.BindPFlag("subscribe-quiet", cmd.LocalFlags().Lookup("quiet"))
 	viper.BindPFlag("subscribe-target", cmd.LocalFlags().Lookup("target"))
 	viper.BindPFlag("subscribe-name", cmd.LocalFlags().Lookup("name"))
+	viper.BindPFlag("subscribe-output", cmd.LocalFlags().Lookup("output"))
 }
 
 func getOutputs(ctx context.Context) (map[string][]outputs.Output, error) {
@@ -286,7 +289,23 @@ func getOutputs(ctx context.Context) (map[string][]outputs.Output, error) {
 			return nil, fmt.Errorf("unknown configuration format: %T : %v", d, d)
 		}
 	}
-	return outputDestinations, nil
+	namedOutputs := viper.GetStringSlice("subscribe-output")
+	if len(namedOutputs) == 0 {
+		return outputDestinations, nil
+	}
+	filteredOutputs := make(map[string][]outputs.Output)
+	notFound := make([]string, 0)
+	for _, name := range namedOutputs {
+		if o, ok := outputDestinations[name]; ok {
+			filteredOutputs[name] = o
+		} else {
+			notFound = append(notFound, name)
+		}
+	}
+	if len(notFound) > 0 {
+		return nil, fmt.Errorf("named output(s) not found in config file: %v", notFound)
+	}
+	return filteredOutputs, nil
 }
 
 func getSubscriptions() (map[string]*collector.SubscriptionConfig, error) {

--- a/docs/cmd/subscribe.md
+++ b/docs/cmd/subscribe.md
@@ -89,6 +89,11 @@ When the `[--updates-only]` flag is set to true, the target MUST not transmit th
 #### name
 The `[--name]` flag is used to trigger one or multiple subscriptions already defined in the configuration file see [defining subscriptions](../advanced/subscriptions.md)
 
+#### output
+The `[--output]` flag is used to select one or multiple output already defined in the configuration file. 
+
+Outputs defined under target take precedence over this flag, see [defining outputs](../advanced/multi_outputs/output_intro.md) and [defining targets](../advanced/multi_targets)
+
 ### Examples
 #### 1. streaming, target-defined, 10s interval
 ```bash


### PR DESCRIPTION
This PR adds the `--output` flag to `subscribe` cmd.
It allows to choose a subset of the output groups defined in the config file to send subscription data to.

The outputs defined under each target take precedence over this flag.