### PR TITLE
Output config

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,107 +1,99 @@
 {
-  "username": "admin",
-  "password": "sros",
-  "port": 57400,
-  "timeout": "5s",
-  "skip-verify": true,
-  "tls-key": "/path/to/client.key",
-  "tls-cert": "/path/to/client.crt",
-  "tls-ca": "/path/to/ca.crt",
-  "targets": {
-    "172.17.0.100": {
-      "timeout": "2s",
-      "subscriptions": [
-        "sub1"
-      ],
-      "outputs": [
-        "group1",
-        "group3"
-      ]
+    "username": "admin",
+    "password": "sros",
+    "port": 57400,
+    "timeout": "5s",
+    "skip-verify": true,
+    "tls-key": "/path/to/client.key",
+    "tls-cert": "/path/to/client.crt",
+    "tls-ca": "/path/to/ca.crt",
+    "targets": {
+        "172.17.0.100": {
+            "timeout": "2s",
+            "subscriptions": [
+                "sub1"
+            ],
+            "outputs": [
+                "output1",
+                "output3"
+            ]
+        },
+        "172.17.0.101": {
+            "username": "sros",
+            "password": "sros",
+            "insecure": true,
+            "subscriptions": [
+                "sub2"
+            ],
+            "outputs": [
+                "output2",
+                "output3"
+            ]
+        },
+        "172.17.0.102:57000": {
+            "password": "sros123",
+            "tls-key": "/path/file1",
+            "tls-cert": "/path/file2"
+        },
+        "172.17.0.103": null
     },
-    "172.17.0.101": {
-      "username": "sros",
-      "password": "sros",
-      "insecure": true,
-      "subscriptions": [
-        "sub2"
-      ],
-      "outputs": [
-        "group2",
-        "group3"
-      ]
+    "subscriptions": {
+        "sub1": {
+            "paths": [
+                "/configure/port[port-id=*]",
+                "/state/port[port-id=*]"
+            ],
+            "stream-mode": "on_change"
+        },
+        "sub2": {
+            "paths": [
+                "/configure/port[port-id=*]/statistics"
+            ],
+            "stream-mode": "sample",
+            "sample-interval": "10s"
+        }
     },
-    "172.17.0.102:57000": {
-      "password": "sros123",
-      "tls-key": "/path/file1",
-      "tls-cert": "/path/file2"
-    },
-    "172.17.0.103": null
-  },
-  "subscriptions": {
-    "sub1": {
-      "paths": [
-        "/configure/port[port-id=*]",
-        "/state/port[port-id=*]"
-      ],
-      "stream-mode": "on_change"
-    },
-    "sub2": {
-      "paths": [
-        "/configure/port[port-id=*]/statistics"
-      ],
-      "stream-mode": "sample",
-      "sample-interval": "10s"
+    "outputs": {
+        "output1": {
+            "type": "file",
+            "file-type": "stdout"
+        },
+        "output2": {
+            "type": "file",
+            "filename": "local.log"
+        },
+        "output3": {
+            "type": "nats",
+            "address": "localhost:4222",
+            "subject-prefix": "telemetry",
+            "username": null,
+            "password": null
+        },
+        "output4": {
+            "type": "stan",
+            "address": "localhost:4223",
+            "subject": "telemetry",
+            "username": null,
+            "password": null,
+            "name": null,
+            "cluster-name": "test-cluster",
+            "timeout": null,
+            "ping-interval": null,
+            "ping-retry": null
+        },
+        "output5": {
+            "type": "kafka",
+            "address": "localhost:9092",
+            "topic": "telemetry",
+            "max-retry": null,
+            "timeout": null
+        },
+        "output6": {
+            "type": "nats",
+            "address": "localhost:4222",
+            "subject-prefix": "telemetry",
+            "username": null,
+            "password": null
+        }
     }
-  },
-  "outputs": {
-    "group1": [
-      {
-        "type": "file",
-        "file-type": "stdout"
-      }
-    ],
-    "group2": [
-      {
-        "type": "file",
-        "filename": "local.log"
-      },
-      {
-        "type": "nats",
-        "address": "localhost:4222",
-        "subject-prefix": "telemetry",
-        "username": null,
-        "password": null
-      }
-    ],
-    "group3": [
-      {
-        "type": "stan",
-        "address": "localhost:4223",
-        "subject": "telemetry",
-        "username": null,
-        "password": null,
-        "name": null,
-        "cluster-name": "test-cluster",
-        "timeout": null,
-        "ping-interval": null,
-        "ping-retry": null
-      }
-    ],
-    "group4": [
-      {
-        "type": "kafka",
-        "address": "localhost:9092",
-        "topic": "telemetry",
-        "max-retry": null,
-        "timeout": null
-      },
-      {
-        "type": "nats",
-        "address": "localhost:4222",
-        "subject-prefix": "telemetry",
-        "username": null,
-        "password": null
-      }
-    ]
-  }
 }

--- a/config.toml
+++ b/config.toml
@@ -8,80 +8,66 @@ tls-cert = "/path/to/client.crt"
 tls-ca = "/path/to/ca.crt"
 
 [targets]
-
   [targets."172.17.0.100"]
   timeout = "2s"
-  subscriptions = [
-    "sub1"
-  ]
-  ouputs = [
-    "group1",
-    "group3"
-  ]
+  subscriptions = [ "sub1" ]
+  outputs = [ 
+    "output1", 
+    "output3"
+    ]
 
   [targets."172.17.0.101"]
   username = "sros"
   password = "sros"
   insecure = true
-  subscriptions = [
-    "sub2"
-  ]
-  outputs = [
-    "group2",
-    "group3"
-  ]
+  subscriptions = [ "sub2" ]
+  outputs = [ 
+    "output2", 
+    "output3" 
+    ]
 
   [targets."172.17.0.102:57000"]
   password = "sros123"
   tls-key = "/path/file1"
   tls-cert = "/path/file2"
 
-  [targets."172.17.0.103"]
-
-[subscriptions]
-
-  [subscriptions.sub1]
-  paths = [
-    "/configure/port[port-id=*]",
-    "/state/port[port-id=*]"
+[subscriptions.sub1]
+paths = [ 
+  "/configure/port[port-id=*]", 
+  "/state/port[port-id=*]" 
   ]
-  stream-mode = "on_change"
+stream-mode = "on_change"
 
-  [subscriptions.sub2]
-  paths = [
-    "/configure/port[port-id=*]/statistics"
-  ]
-  stream-mode = "sample"
-  sample-interval = "10s"
+[subscriptions.sub2]
+paths = [ "/configure/port[port-id=*]/statistics" ]
+stream-mode = "sample"
+sample-interval = "10s"
 
-[outputs]
+[outputs.output1]
+type = "file"
+file-type = "stdout"
 
-  [[outputs.group1]]
-  type = "file"
-  file-type = "stdout"
+[outputs.output2]
+type = "file"
+filename = "local.log"
 
-  [[outputs.group2]]
-  type = "file"
-  filename = "local.log"
+[outputs.output3]
+type = "nats"
+address = "localhost:4222"
+subject-prefix = "telemetry"
 
-  [[outputs.group2]]
-  type = "nats"
-  address = "localhost:4222"
-  subject-prefix = "telemetry"
+[outputs.output4]
+type = "stan"
+address = "localhost:4223"
+subject = "telemetry"
+cluster-name = "test-cluster"
 
-  [[outputs.group3]]
-  type = "stan"
-  address = "localhost:4223"
-  subject = "telemetry"
-  cluster-name = "test-cluster"
+[outputs.output5]
+type = "kafka"
+address = "localhost:9092"
+topic = "telemetry"
 
-  [[outputs.group4]]
-  type = "kafka"
-  address = "localhost:9092"
-  topic = "telemetry"
-
-  [[outputs.group4]]
-  type = "nats"
-  address = "localhost:4222"
-  subject-prefix = "telemetry"
-  
+[outputs.output6]
+type = "nats"
+address = "localhost:4222"
+subject-prefix = "telemetry"

--- a/config.yaml
+++ b/config.yaml
@@ -13,8 +13,8 @@ targets:
     subscriptions:
       - sub1
     outputs:
-      - group1
-      - group3
+      - output1
+      - output3
   172.17.0.101:
     username: sros
     password: sros
@@ -22,8 +22,8 @@ targets:
     subscriptions:
       - sub2
     outputs:
-      - group2
-      - group3
+      - output2
+      - output3
   172.17.0.102:57000:
     password: sros123
     tls-key: /path/file1
@@ -43,36 +43,38 @@ subscriptions:
     sample-interval: 10s
 
 outputs:
-  group1:
-    - type: file
-      file-type: stdout
-  group2:
-    - type: file
-      filename: local.log
-    - type: nats
-      address: localhost:4222
-      subject-prefix: telemetry
-      username:
-      password:
-  group3:
-    - type: stan
-      address: localhost:4223
-      subject: telemetry
-      username:
-      password:
-      name: 
-      cluster-name: test-cluster
-      timeout:
-      ping-interval:
-      ping-retry:
-  group4:
-    - type: kafka
-      address: localhost:9092
-      topic: telemetry
-      max-retry: 
-      timeout:
-    - type: nats
-      address: localhost:4222
-      subject-prefix: telemetry
-      username:
-      password:
+  output1:
+    type: file
+    file-type: stdout
+  output2:
+    type: file
+    filename: local.log
+  output3:
+    type: nats
+    address: localhost:4222
+    subject-prefix: telemetry
+    username:
+    password:
+  output4:
+    type: stan
+    address: localhost:4223
+    subject: telemetry
+    username:
+    password:
+    name: 
+    cluster-name: test-cluster
+    timeout:
+    ping-interval:
+    ping-retry:
+  output5:
+    type: kafka
+    address: localhost:9092
+    topic: telemetry
+    max-retry: 
+    timeout:
+  output6:
+    type: nats
+    address: localhost:4222
+    subject-prefix: telemetry
+    username:
+    password:

--- a/docs/advanced/multi_outputs/file_output.md
+++ b/docs/advanced/multi_outputs/file_output.md
@@ -4,10 +4,10 @@ A file output can be defined using the below format in `gnmic` config file under
 
 ```yaml
 outputs:
-  group1:
-    - type: file # required
-      file-name: /path/to/filename
-      file-type: stdout # or stderr
+  output1:
+    type: file # required
+    file-name: /path/to/filename
+    file-type: stdout # or stderr
 ```
 
 The file output can be used to write to file on the disk, to stdout or to stderr.

--- a/docs/advanced/multi_outputs/influxdb_output.md
+++ b/docs/advanced/multi_outputs/influxdb_output.md
@@ -4,18 +4,18 @@ An influxdb output can be defined using the below format in `gnmic` config file 
 
 ```yaml
 outputs:
-  group1:
-    - type: influxdb # required
-      url: http://localhost:8086 # influxDB server address
-      org: myOrg # empty if using influxdb1.8.x
-      bucket: telemetry # string in the form database/retention-policy. Skip retention policy for the default on
-      token: # influxdb 1.8.x use a string in the form: "username:password"
-      batch_size: 1000 # number of points to buffer before writing to the server
-      flush_timer: 10s # flush period after which the buffer is written to the server whether the batch_size is reached or not
-      use_gzip: false
-      enable_tls: false
-      health_check_period: 30s # server health check period, used to recover from server connectivity failure
-      debug: false # enable debug
+  output1:
+    type: influxdb # required
+    url: http://localhost:8086 # influxDB server address
+    org: myOrg # empty if using influxdb1.8.x
+    bucket: telemetry # string in the form database/retention-policy. Skip retention policy for the default on
+    token: # influxdb 1.8.x use a string in the form: "username:password"
+    batch_size: 1000 # number of points to buffer before writing to the server
+    flush_timer: 10s # flush period after which the buffer is written to the server whether the batch_size is reached or not
+    use_gzip: false
+    enable_tls: false
+    health_check_period: 30s # server health check period, used to recover from server connectivity failure
+    debug: false # enable debug
 ```
 
 `gnmic` uses the [`event`](../output_intro#formats-examples) format to generate the measurements written to influxdb

--- a/docs/advanced/multi_outputs/kafka_output.md
+++ b/docs/advanced/multi_outputs/kafka_output.md
@@ -4,12 +4,12 @@ A Kafka output can be defined using the below format in `gnmic` config file unde
 
 ```yaml
 outputs:
-  group1:
-    - type: kafka # required
-      address: localhost:9092 # comma separated brokers addresses
-      topic: telemetry # topic name
-      max-retry: # max number of retries retry
-      timeout: # kafka connection timeout
+  output1:
+    type: kafka # required
+    address: localhost:9092 # comma separated brokers addresses
+    topic: telemetry # topic name
+    max-retry: # max number of retries retry
+    timeout: # kafka connection timeout
 ```
 
 Currently all subscriptions updates (all targets and all subscriptions) are published to the defined topic name

--- a/docs/advanced/multi_outputs/nats_output.md
+++ b/docs/advanced/multi_outputs/nats_output.md
@@ -4,14 +4,14 @@ A [NATS](https://docs.nats.io/) output can be defined using the below format in 
 
 ```yaml
 outputs:
-  group1:
-    - type: nats # required
-      address: localhost:4222 # comma separated NATS servers
-      subject-prefix: telemetry # this prefix is used to to build the subject name for each target/subscription
-      subject: telemetry # if a subject-prefix is not specified, gnmic will publish all subscriptions updates to a single subject 'telemetry'
-      username: # NATS username
-      password: # NATS password  
-      connect-time-wait: # wait time before reconnection attempts
+  output1:
+    type: nats # required
+    address: localhost:4222 # comma separated NATS servers
+    subject-prefix: telemetry # this prefix is used to to build the subject name for each target/subscription
+    subject: telemetry # if a subject-prefix is not specified, gnmic will publish all subscriptions updates to a single subject 'telemetry'
+    username: # NATS username
+    password: # NATS password  
+    connect-time-wait: # wait time before reconnection attempts
 ```
 
 Using `subject` config value a user can specify the NATS subject to which to send all subscriptions updates for all targets

--- a/docs/advanced/multi_outputs/output_intro.md
+++ b/docs/advanced/multi_outputs/output_intro.md
@@ -23,39 +23,40 @@ To define an output a user needs to create the `outputs` section in the configur
 ```yaml
 # part of ~/gnmic.yml config file
 outputs:
-  group1:
-    - type: file # output type
-      file-type: stdout # or stderr
-      format: json
-    - type: file
-      filename: /path/to/localFile.log  
-      format: protojson
-  group2:
-    - type: nats # output type
-      address: 127.0.0.1:4222 # comma separated nats servers addresses
-      subject-prefix: telemetry #
-      format: event
-    - type: file
-      filename: /path/to/localFile.log  
-      format: json
-  group3:
-    - type: stan # output type
-      address: 127.0.0.1:4223 # comma separated nats streaming servers addresses
-      subject: telemetry #
-      cluster-name: test-cluster #
-      format: proto
-  group4:
-    - type: kafka # output type
-      address: localhost:9092 # comma separated kafka brokers addresses
-      topic: telemetry # kafka topic
-      format: proto
-    - type: stan # output type
-      address: 127.0.0.1:4223 # comma separated nats streaming servers addresses
-      subject: telemetry
-      cluster-name: test-cluster
+  output1:
+    type: file # output type
+    file-type: stdout # or stderr
+    format: json
+  output2:
+    type: file
+    filename: /path/to/localFile.log  
+    format: protojson
+  output3:
+    type: nats # output type
+    address: 127.0.0.1:4222 # comma separated nats servers addresses
+    subject-prefix: telemetry #
+    format: event
+  output4:
+    type: file
+    filename: /path/to/localFile.log  
+    format: json
+  output5:
+    type: stan # output type
+    address: 127.0.0.1:4223 # comma separated nats streaming servers addresses
+    subject: telemetry #
+    cluster-name: test-cluster #
+    format: proto
+  output6:
+    type: kafka # output type
+    address: localhost:9092 # comma separated kafka brokers addresses
+    topic: telemetry # kafka topic
+    format: proto
+  output7:
+    type: stan # output type
+    address: 127.0.0.1:4223 # comma separated nats streaming servers addresses
+    subject: telemetry
+    cluster-name: test-cluster
 ```
-
-Outputs can be defined in groups to be able to match a target with multiple outputs at once,
 
 #### Output formats
 
@@ -174,13 +175,13 @@ targets:
     username: admin
     password: secret
     outputs:
-      - group1
-      - group3
+      - output1
+      - output3
   router2.lab.com:
     username: gnmi
     password: telemetry
     outputs:
-      - group2
-      - group3
-      - group4
+      - output2
+      - output3
+      - output4
 ```

--- a/docs/advanced/multi_outputs/prometheus_output.md
+++ b/docs/advanced/multi_outputs/prometheus_output.md
@@ -4,12 +4,12 @@ A Prometheus output can be defined using the below format in `gnmic` config file
 
 ```yaml
 outputs:
-  group1:
-    - type: prometheus # required
-      listen: :9804 # address to listen on for incoming scape requests
-      path: /metrics # path to query to get the metrics
-      expiration: 60s # maximum lifetime of metrics in the local cache
-      debug: false # enable debug for prometheus output
+  output1:
+    type: prometheus # required
+    listen: :9804 # address to listen on for incoming scape requests
+    path: /metrics # path to query to get the metrics
+    expiration: 60s # maximum lifetime of metrics in the local cache
+    debug: false # enable debug for prometheus output
 ```
 
 `gnmic` creates the prometheus metric name and its labels from the subscription name, the gnmic path and the value name.

--- a/docs/advanced/multi_outputs/stan_output.md
+++ b/docs/advanced/multi_outputs/stan_output.md
@@ -4,18 +4,18 @@ A STAN output can be defined using the below format in `gnmic` config file under
 
 ```yaml
 outputs:
-  group1:
-    - type: stan # required
-      address: localhost:4223 # comma separated STAN servers
-      subject: telemetry # stan subject
-      subject-prefix: telemetry # stan subject prefix, the subject prefix is built the same way as for NATS output
-      username: # STAN username
-      password: # STAN password
-      name: # client name
-      cluster-name: test-cluster # cluster name
-      timeout: # connection timeout
-      ping-interval: # STAN ping interval
-      ping-retry: # STAN ping retry
+  output1:
+    type: stan # required
+    address: localhost:4223 # comma separated STAN servers
+    subject: telemetry # stan subject
+    subject-prefix: telemetry # stan subject prefix, the subject prefix is built the same way as for NATS output
+    username: # STAN username
+    password: # STAN password
+    name: # client name
+    cluster-name: test-cluster # cluster name
+    timeout: # connection timeout
+    ping-interval: # STAN ping interval
+    ping-retry: # STAN ping retry
 ```
 
 Using `subject` config value a user can specify the STAN subject to which to send all subscriptions updates for all targets

--- a/docs/advanced/multi_outputs/tcp_output.md
+++ b/docs/advanced/multi_outputs/tcp_output.md
@@ -4,14 +4,14 @@ A TCP output can be defined using the below format in `gnmic` config file under 
 
 ```yaml
 outputs:
-  group1:
-    - type: tcp # required
-      address: IPAddress:Port # a UDP server address 
-      rate: 10ms # maximum sending rate, e.g: 1ns, 10ms
-      buffer-size: # number of messages to buffer in case of sending failure
-      format: json # export format. json, protobuf, prototext, protojson, event
-      keep-alive: # enable TCP keepalive and specify the timer, e.g: 1s, 30s
-      retry-interval: # time duration to wait before re-dial in case there is a failure
+  output1:
+    type: tcp # required
+    address: IPAddress:Port # a UDP server address 
+    rate: 10ms # maximum sending rate, e.g: 1ns, 10ms
+    buffer-size: # number of messages to buffer in case of sending failure
+    format: json # export format. json, protobuf, prototext, protojson, event
+    keep-alive: # enable TCP keepalive and specify the timer, e.g: 1s, 30s
+    retry-interval: # time duration to wait before re-dial in case there is a failure
 ```
 
 A TCP output can be used to export data to an ELK stack, using [Logstash TCP input](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-tcp.html)

--- a/docs/advanced/multi_outputs/udp_output.md
+++ b/docs/advanced/multi_outputs/udp_output.md
@@ -4,13 +4,13 @@ A UDP output can be defined using the below format in `gnmic` config file under 
 
 ```yaml
 outputs:
-  group1:
-    - type: udp # required
-      address: IPAddress:Port # a UDP server address 
-      rate: 10ms # maximum sending rate, e.g: 1ns, 10ms
-      buffer-size: # number of messages to buffer in case of sending failure
-      format: json # export format. json, protobuf, prototext, protojson, event
-      retry-interval: # time duration to wait before re-dial in case there is a failure
+  output1:
+    type: udp # required
+    address: IPAddress:Port # a UDP server address 
+    rate: 10ms # maximum sending rate, e.g: 1ns, 10ms
+    buffer-size: # number of messages to buffer in case of sending failure
+    format: json # export format. json, protobuf, prototext, protojson, event
+    retry-interval: # time duration to wait before re-dial in case there is a failure
 ```
 
 A UDP output can be used to export data to an ELK stack, using [Logstash UDP input](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-udp.html)

--- a/outputs/influxdb_output/influxdb_output.go
+++ b/outputs/influxdb_output/influxdb_output.go
@@ -154,11 +154,8 @@ func (i *InfluxDBOutput) Write(ctx context.Context, rsp proto.Message, meta outp
 }
 
 func (i *InfluxDBOutput) Close() error {
-	i.logger.Printf("flushing data...")
 	i.logger.Printf("closing client...")
-	i.client.Close()
 	i.cancelFn()
-	close(i.eventChan)
 	i.logger.Printf("closed.")
 	return nil
 }
@@ -219,7 +216,7 @@ START:
 	}
 	i.logger.Printf("starting worker-%d", idx)
 	writer := i.client.WriteAPI(i.Cfg.Org, i.Cfg.Bucket)
-	defer writer.Flush()
+	//defer writer.Flush()
 	for {
 		select {
 		case <-ctx.Done():

--- a/outputs/kafka_output/kafka_output.go
+++ b/outputs/kafka_output/kafka_output.go
@@ -154,6 +154,7 @@ func (k *KafkaOutput) Metrics() []prometheus.Collector { return k.metrics }
 func (k *KafkaOutput) worker(ctx context.Context, idx int, config *sarama.Config) {
 	var producer sarama.SyncProducer
 	var err error
+	defer k.wg.Done()
 	k.logger.Printf("starting worker id=%d", idx)
 CRPROD:
 	producer, err = sarama.NewSyncProducer(strings.Split(k.Cfg.Address, ","), config)


### PR DESCRIPTION
Change file config format for outputs sections.
From grouping outputs in a list to a simple map with output name as key.
Later labels can be used to group outputs under specific targets