### PR TITLE
Glob

### DIFF
--- a/cmd/path.go
+++ b/cmd/path.go
@@ -441,26 +441,6 @@ func walkDir(path, ext string) ([]string, error) {
 				return err
 			}
 			switch mode := fi.Mode(); {
-			case mode.IsDir():
-				if debug {
-					fAbs, err := filepath.Abs(fi.Name())
-					if err != nil {
-						fAbs = fi.Name()
-					}
-					logger.Printf("walking directory %s for %s files", fAbs, ext)
-				}
-				ifs, err := walkDir(fi.Name(), ext)
-				if err != nil {
-					return err
-				}
-				for _, f := range ifs {
-					if filepath.Ext(f) == ext {
-						if debug {
-							logger.Printf("appending file %s", f)
-						}
-						fs = append(fs, f)
-					}
-				}
 			case mode.IsRegular():
 				if filepath.Ext(path) == ext {
 					if debug {

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -431,7 +431,8 @@ func buildRootEntry() *yang.Entry {
 func walkDir(path, ext string) ([]string, error) {
 	debug := viper.GetBool("debug")
 	fs := make([]string, 0)
-	filepath.Walk(path,
+	var err error
+	err = filepath.Walk(path,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
@@ -471,6 +472,9 @@ func walkDir(path, ext string) ([]string, error) {
 			}
 			return nil
 		})
+	if err != nil {
+		return nil, err
+	}
 	return fs, nil
 }
 

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -429,7 +429,6 @@ func buildRootEntry() *yang.Entry {
 }
 
 func walkDir(path, ext string) ([]string, error) {
-	debug := viper.GetBool("debug")
 	fs := make([]string, 0)
 	err := filepath.Walk(path,
 		func(path string, info os.FileInfo, err error) error {
@@ -443,9 +442,6 @@ func walkDir(path, ext string) ([]string, error) {
 			switch mode := fi.Mode(); {
 			case mode.IsRegular():
 				if filepath.Ext(path) == ext {
-					if debug {
-						logger.Printf("appending file %s", path)
-					}
 					fs = append(fs, path)
 				}
 			}

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -431,8 +431,7 @@ func buildRootEntry() *yang.Entry {
 func walkDir(path, ext string) ([]string, error) {
 	debug := viper.GetBool("debug")
 	fs := make([]string, 0)
-	var err error
-	err = filepath.Walk(path,
+	err := filepath.Walk(path,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -180,7 +180,7 @@ var pathCmd = &cobra.Command{
 			}
 			if viper.GetBool("debug") {
 				for _, fdir := range expanded {
-					logger.Printf("adding %s to yang Paths", fdir)
+					logger.Printf("adding %s to YANG paths", fdir)
 				}
 			}
 			yang.AddPath(expanded...)
@@ -193,7 +193,7 @@ var pathCmd = &cobra.Command{
 		files = append(files, yfiles...)
 		if viper.GetBool("debug") {
 			for _, file := range files {
-				logger.Printf("loading %s yang file", file)
+				logger.Printf("loading %s file", file)
 			}
 		}
 		return nil

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -74,6 +74,29 @@ var promptModeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		for _, dirpath := range promptDirs {
+			expanded, err := yang.PathsWithModules(dirpath)
+			if err != nil {
+				return err
+			}
+			if viper.GetBool("debug") {
+				for _, fdir := range expanded {
+					logger.Printf("adding %s to yang Paths", fdir)
+				}
+			}
+			yang.AddPath(expanded...)
+		}
+		yfiles, err := findYangFiles(promptFiles)
+		if err != nil {
+			return err
+		}
+		promptFiles = make([]string, 0, len(yfiles))
+		promptFiles = append(promptFiles, yfiles...)
+		if viper.GetBool("debug") {
+			for _, file := range promptFiles {
+				logger.Printf("loading %s yang file", file)
+			}
+		}
 		err = termbox.Init()
 		if err != nil {
 			return fmt.Errorf("could not initialize a terminal box: %v", err)

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -771,4 +772,22 @@ func findSuggestions(co cmdPrompt, doc goprompt.Document) []goprompt.Suggest {
 	}
 
 	return goprompt.FilterHasPrefix(suggestions, doc.GetWordBeforeCursor(), true)
+}
+
+func resolveGlobs(globs []string) ([]string, error) {
+	results := make([]string, 0, len(globs))
+	for _, pattern := range globs {
+		if strings.ContainsAny(pattern, `*?[`) {
+			// is a glob pattern
+			matches, err := filepath.Glob(pattern)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, matches...)
+		} else {
+			// is not a glob pattern ( file or dir )
+			results = append(results, pattern)
+		}
+	}
+	return results, nil
 }


### PR DESCRIPTION
Adds the possibility to pass a glob pattern to `prompt --file` and `prompt --dir`.
globs need to be quoted, e.g: `prompt --file "/path/module-bgp-*.yang"`