### PR TITLE
TLS version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,8 @@ var formats = [][2]string{
 	{"event", "protocol buffer messages as a timestamped list of tags and values"},
 	{"proto", "protocol buffer messages in binary wire format"},
 }
+var tlsVersions = []string{"1.3", "1.2", "1.1", "1.0"}
+
 var cfgFile string
 var f io.WriteCloser
 var logger *log.Logger
@@ -184,6 +186,9 @@ func init() {
 	rootCmd.PersistentFlags().StringP("prometheus-address", "", "", "prometheus server address")
 	rootCmd.PersistentFlags().BoolP("print-request", "", false, "print request as well as the response(s)")
 	rootCmd.PersistentFlags().DurationP("retry", "", defaultRetryTimer, "retry timer for RPCs")
+	rootCmd.PersistentFlags().StringP("tls-min-version", "", "", fmt.Sprintf("minium TLS supported version, one of %v", tlsVersions))
+	rootCmd.PersistentFlags().StringP("tls-max-version", "", "", fmt.Sprintf("maximum TLS supported version, one of %v", tlsVersions))
+	rootCmd.PersistentFlags().StringP("tls-version", "", "", fmt.Sprintf("set TLS version, one of %v", tlsVersions))
 	//
 	viper.BindPFlag("address", rootCmd.PersistentFlags().Lookup("address"))
 	viper.BindPFlag("username", rootCmd.PersistentFlags().Lookup("username"))
@@ -206,6 +211,9 @@ func init() {
 	viper.BindPFlag("prometheus-address", rootCmd.PersistentFlags().Lookup("prometheus-address"))
 	viper.BindPFlag("print-request", rootCmd.PersistentFlags().Lookup("print-request"))
 	viper.BindPFlag("retry", rootCmd.PersistentFlags().Lookup("retry"))
+	viper.BindPFlag("tls-min-version", rootCmd.PersistentFlags().Lookup("tls-min-version"))
+	viper.BindPFlag("tls-max-version", rootCmd.PersistentFlags().Lookup("tls-max-version"))
+	viper.BindPFlag("tls-version", rootCmd.PersistentFlags().Lookup("tls-version"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -556,6 +556,15 @@ func setTargetConfigDefaults(tc *collector.TargetConfig) {
 	if tc.RetryTimer == 0 {
 		tc.RetryTimer = viper.GetDuration("retry")
 	}
+	if tc.TlsVersion == "" {
+		tc.TlsVersion = viper.GetString("tls-version")
+	}
+	if tc.TlsMinVersion == "" {
+		tc.TlsMinVersion = viper.GetString("tls-min-version")
+	}
+	if tc.TlsMaxVersion == "" {
+		tc.TlsMaxVersion = viper.GetString("tls-max-version")
+	}
 }
 
 func createCollectorDialOpts() []grpc.DialOption {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -556,14 +556,14 @@ func setTargetConfigDefaults(tc *collector.TargetConfig) {
 	if tc.RetryTimer == 0 {
 		tc.RetryTimer = viper.GetDuration("retry")
 	}
-	if tc.TlsVersion == "" {
-		tc.TlsVersion = viper.GetString("tls-version")
+	if tc.TLSVersion == "" {
+		tc.TLSVersion = viper.GetString("tls-version")
 	}
-	if tc.TlsMinVersion == "" {
-		tc.TlsMinVersion = viper.GetString("tls-min-version")
+	if tc.TLSMinVersion == "" {
+		tc.TLSMinVersion = viper.GetString("tls-min-version")
 	}
-	if tc.TlsMaxVersion == "" {
-		tc.TlsMaxVersion = viper.GetString("tls-max-version")
+	if tc.TLSMaxVersion == "" {
+		tc.TLSMaxVersion = viper.GetString("tls-max-version")
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,7 +79,7 @@ var formats = [][2]string{
 	{"event", "protocol buffer messages as a timestamped list of tags and values"},
 	{"proto", "protocol buffer messages in binary wire format"},
 }
-var tlsVersions = []string{"1.3", "1.2", "1.1", "1.0"}
+var tlsVersions = []string{"1.3", "1.2", "1.1", "1.0", "1"}
 
 var cfgFile string
 var f io.WriteCloser
@@ -186,9 +186,9 @@ func init() {
 	rootCmd.PersistentFlags().StringP("prometheus-address", "", "", "prometheus server address")
 	rootCmd.PersistentFlags().BoolP("print-request", "", false, "print request as well as the response(s)")
 	rootCmd.PersistentFlags().DurationP("retry", "", defaultRetryTimer, "retry timer for RPCs")
-	rootCmd.PersistentFlags().StringP("tls-min-version", "", "", fmt.Sprintf("minium TLS supported version, one of %v", tlsVersions))
-	rootCmd.PersistentFlags().StringP("tls-max-version", "", "", fmt.Sprintf("maximum TLS supported version, one of %v", tlsVersions))
-	rootCmd.PersistentFlags().StringP("tls-version", "", "", fmt.Sprintf("set TLS version, one of %v", tlsVersions))
+	rootCmd.PersistentFlags().StringP("tls-min-version", "", "", fmt.Sprintf("minium TLS supported version, one of %q", tlsVersions))
+	rootCmd.PersistentFlags().StringP("tls-max-version", "", "", fmt.Sprintf("maximum TLS supported version, one of %q", tlsVersions))
+	rootCmd.PersistentFlags().StringP("tls-version", "", "", fmt.Sprintf("set TLS version. Overwrites --tls-min-version and --tls-max-version, one of %q", tlsVersions))
 	//
 	viper.BindPFlag("address", rootCmd.PersistentFlags().Lookup("address"))
 	viper.BindPFlag("username", rootCmd.PersistentFlags().Lookup("username"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -186,7 +186,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("prometheus-address", "", "", "prometheus server address")
 	rootCmd.PersistentFlags().BoolP("print-request", "", false, "print request as well as the response(s)")
 	rootCmd.PersistentFlags().DurationP("retry", "", defaultRetryTimer, "retry timer for RPCs")
-	rootCmd.PersistentFlags().StringP("tls-min-version", "", "", fmt.Sprintf("minium TLS supported version, one of %q", tlsVersions))
+	rootCmd.PersistentFlags().StringP("tls-min-version", "", "", fmt.Sprintf("minimum TLS supported version, one of %q", tlsVersions))
 	rootCmd.PersistentFlags().StringP("tls-max-version", "", "", fmt.Sprintf("maximum TLS supported version, one of %q", tlsVersions))
 	rootCmd.PersistentFlags().StringP("tls-version", "", "", fmt.Sprintf("set TLS version. Overwrites --tls-min-version and --tls-max-version, one of %q", tlsVersions))
 	//

--- a/collector/target.go
+++ b/collector/target.go
@@ -58,9 +58,9 @@ type TargetConfig struct {
 	Outputs       []string      `mapstructure:"outputs,omitempty"`
 	BufferSize    uint          `mapstructure:"buffer-size,omitempty"`
 	RetryTimer    time.Duration `mapstructure:"retry,omitempty"`
-	TlsMinVersion string        `mapstructure:"tls-min-version,omitempty"`
-	TlsMaxVersion string        `mapstructure:"tls-max-version,omitempty"`
-	TlsVersion    string        `mapstructure:"tls-version,omitempty"`
+	TLSMinVersion string        `mapstructure:"tls-min-version,omitempty"`
+	TLSMaxVersion string        `mapstructure:"tls-max-version,omitempty"`
+	TLSVersion    string        `mapstructure:"tls-version,omitempty"`
 }
 
 func (tc *TargetConfig) String() string {
@@ -90,8 +90,8 @@ func (tc *TargetConfig) newTLS() (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		Renegotiation:      tls.RenegotiateNever,
 		InsecureSkipVerify: *tc.SkipVerify,
-		MaxVersion:         tc.getTlsMaxVersion(),
-		MinVersion:         tc.getTlsMinVersion(),
+		MaxVersion:         tc.getTLSMaxVersion(),
+		MinVersion:         tc.getTLSMinVersion(),
 	}
 	err := loadCerts(tlsConfig, tc)
 	if err != nil {
@@ -301,20 +301,20 @@ func (t *Target) numberOfOnceSubscriptions() int {
 	return num
 }
 
-func (tc *TargetConfig) getTlsMinVersion() uint16 {
-	v := tlsVersionStringToUint(tc.TlsVersion)
+func (tc *TargetConfig) getTLSMinVersion() uint16 {
+	v := tlsVersionStringToUint(tc.TLSVersion)
 	if v > 0 {
 		return v
 	}
-	return tlsVersionStringToUint(tc.TlsMinVersion)
+	return tlsVersionStringToUint(tc.TLSMinVersion)
 }
 
-func (tc *TargetConfig) getTlsMaxVersion() uint16 {
-	v := tlsVersionStringToUint(tc.TlsVersion)
+func (tc *TargetConfig) getTLSMaxVersion() uint16 {
+	v := tlsVersionStringToUint(tc.TLSVersion)
 	if v > 0 {
 		return v
 	}
-	return tlsVersionStringToUint(tc.TlsMaxVersion)
+	return tlsVersionStringToUint(tc.TLSMaxVersion)
 }
 
 func tlsVersionStringToUint(v string) uint16 {

--- a/collector/target.go
+++ b/collector/target.go
@@ -58,6 +58,9 @@ type TargetConfig struct {
 	Outputs       []string      `mapstructure:"outputs,omitempty"`
 	BufferSize    uint          `mapstructure:"buffer-size,omitempty"`
 	RetryTimer    time.Duration `mapstructure:"retry,omitempty"`
+	TlsMinVersion string        `mapstructure:"tls-min-version,omitempty"`
+	TlsMaxVersion string        `mapstructure:"tls-max-version,omitempty"`
+	TlsVersion    string        `mapstructure:"tls-version,omitempty"`
 }
 
 func (tc *TargetConfig) String() string {

--- a/collector/target.go
+++ b/collector/target.go
@@ -90,6 +90,8 @@ func (tc *TargetConfig) newTLS() (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		Renegotiation:      tls.RenegotiateNever,
 		InsecureSkipVerify: *tc.SkipVerify,
+		MaxVersion:         tc.getTlsMaxVersion(),
+		MinVersion:         tc.getTlsMinVersion(),
 	}
 	err := loadCerts(tlsConfig, tc)
 	if err != nil {
@@ -297,4 +299,35 @@ func (t *Target) numberOfOnceSubscriptions() int {
 		}
 	}
 	return num
+}
+
+func (tc *TargetConfig) getTlsMinVersion() uint16 {
+	v := tlsVersionStringToUint(tc.TlsVersion)
+	if v > 0 {
+		return v
+	}
+	return tlsVersionStringToUint(tc.TlsMinVersion)
+}
+
+func (tc *TargetConfig) getTlsMaxVersion() uint16 {
+	v := tlsVersionStringToUint(tc.TlsVersion)
+	if v > 0 {
+		return v
+	}
+	return tlsVersionStringToUint(tc.TlsMaxVersion)
+}
+
+func tlsVersionStringToUint(v string) uint16 {
+	switch v {
+	default:
+		return 0
+	case "1.3":
+		return tls.VersionTLS13
+	case "1.2":
+		return tls.VersionTLS12
+	case "1.1":
+		return tls.VersionTLS11
+	case "1.0", "1":
+		return tls.VersionTLS10
+	}
 }

--- a/docs/advanced/multi_target.md
+++ b/docs/advanced/multi_target.md
@@ -59,6 +59,9 @@ targets:
     tls-ca:
     tls-cert:
     tls-key:
+    tls-max-version:
+    tls-min-version:
+    tls-version:
     skip-verify:
     subscriptions:
     outputs:

--- a/docs/global_flags.md
+++ b/docs/global_flags.md
@@ -175,5 +175,16 @@ The tls cert flag `[--tls-cert]` specifies the public key for the client encoded
 ### tls-key
 The tls key flag `[--tls-key]` specifies the private key for the client encoded in PEM format
 
+### tls-max-version
+The tls max version flag `[--tls-max-version]` specifies the maximum supported TLS version supported by gNMIc when creating a secure gRPC connection
+
+### tls-min-version
+The tls min version flag `[--tls-min-version]` specifies the minimum supported TLS version supported by gNMIc when creating a secure gRPC connection
+
+### tls-version
+The tls version flag `[--tls-version]` specifies a single supported TLS version gNMIc when creating a secure gRPC connection.
+
+This flag overwrites the previously listed flags `--tls-max-version` and `--tls-min-version`.
+
 ### username
 The username flag `[-u | --username]` is used to specify the target username as part of the user credentials. If omitted, the input prompt is used to provide the username.


### PR DESCRIPTION
This PR add 3 flags to tweak the TLS version used by secure connections:
`--tls-max-version string      maximum TLS supported version, one of ["1.3" "1.2" "1.1" "1.0" "1"]`

`--tls-min-version string      minimum TLS supported version, one of ["1.3" "1.2" "1.1" "1.0" "1"]`

` --tls-version string          set TLS version. Overwrites --tls-min-version and --tls-max-version, one of ["1.3" "1.2" "1.1" "1.0" "1"]`