### PR TITLE
Bump upx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.13
 
       - name: Install upx
-        run: sudo apt update && sudo apt install libucl1 && curl -L http://archive.ubuntu.com/ubuntu/pool/universe/u/upx-ucl/upx-ucl_3.96-2_amd64.deb -o upx.deb && dpkg -i upx.deb
+        run: sudo apt update && sudo apt install -y libucl1 && curl -L http://archive.ubuntu.com/ubuntu/pool/universe/u/upx-ucl/upx-ucl_3.96-2_amd64.deb -o upx.deb && sudo dpkg -i upx.deb
 
       - name: Login to dockerhub
         run: docker login -u vikar2 -p ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - v*
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -17,7 +17,7 @@ jobs:
           CGO_ENABLED: 0
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - test
     steps:
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.13
 
       - name: Install upx
-        run: sudo apt update && sudo apt install upx -y
+        run: sudo apt update && sudo apt install libucl1 && curl -L http://archive.ubuntu.com/ubuntu/pool/universe/u/upx-ucl/upx-ucl_3.96-2_amd64.deb -o upx.deb && dpkg -i upx.deb
 
       - name: Login to dockerhub
         run: docker login -u vikar2 -p ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2


### PR DESCRIPTION
fixes #221 

upx 3.96 promises to fix the issue with Big Sur

To install upx 3.96 I had upgrade the runners system to run ubuntu 20.04. Anyhow, soon it will become ubuntu-latest, so should be all fine