### PR TITLE
Fixed issue where SIGINT wasn't honored by the `file` Output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ import (
 	"time"
 
 	"github.com/karimra/gnmic/collector"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/mapstructure"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/spf13/cobra"
@@ -350,20 +350,20 @@ func loadCACerts(tlscfg *tls.Config) error {
 func printer(ctx context.Context, c chan string) {
 	for {
 		select {
-		case m := <-c:
-			fmt.Println(m)
 		case <-ctx.Done():
 			return
+		case m := <-c:
+			fmt.Println(m)
 		}
 	}
 }
 func gather(ctx context.Context, c chan string, ls *[]string) {
 	for {
 		select {
-		case m := <-c:
-			*ls = append(*ls, m)
 		case <-ctx.Done():
 			return
+		case m := <-c:
+			*ls = append(*ls, m)
 		}
 	}
 }

--- a/cmd/subscribe.go
+++ b/cmd/subscribe.go
@@ -166,6 +166,8 @@ var subscribeCmd = &cobra.Command{
 			go func() {
 				for {
 					select {
+					case <-gctx.Done():
+						return
 					case <-waitChan:
 						_, name, err := s.Run()
 						if err != nil {
@@ -206,8 +208,6 @@ var subscribeCmd = &cobra.Command{
 						}
 						fmt.Println(string(b))
 						waitChan <- struct{}{}
-					case <-gctx.Done():
-						return
 					}
 				}
 			}()

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -328,6 +328,8 @@ func (c *Collector) Start(ctx context.Context) {
 			numSubscriptions := len(t.Subscriptions)
 			for {
 				select {
+				case <-ctx.Done():
+					return
 				case rsp := <-t.subscribeResponses:
 					if c.Config.Debug {
 						c.logger.Printf("received gNMI Subscribe Response: %+v", rsp)
@@ -364,8 +366,6 @@ func (c *Collector) Start(ctx context.Context) {
 					if remainingOnceSubscriptions == 0 && numSubscriptions == numOnceSubscriptions {
 						return
 					}
-				case <-ctx.Done():
-					return
 				}
 			}
 		}(t)

--- a/collector/target.go
+++ b/collector/target.go
@@ -239,6 +239,8 @@ SUBSC:
 	case gnmi.SubscriptionList_POLL:
 		for {
 			select {
+			case <-nctx.Done():
+				return
 			case subName := <-t.pollChan:
 				err = t.SubscribeClients[subName].Send(&gnmi.SubscribeRequest{
 					Request: &gnmi.SubscribeRequest_Poll{
@@ -264,8 +266,6 @@ SUBSC:
 					SubscriptionName: subscriptionName,
 					Response:         response,
 				}
-			case <-nctx.Done():
-				return
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	google.golang.org/grpc v1.30.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -465,6 +465,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/outputs/influxdb_output/influxdb_output.go
+++ b/outputs/influxdb_output/influxdb_output.go
@@ -172,10 +172,10 @@ func (i *InfluxDBOutput) healthCheck(ctx context.Context) {
 	ticker := time.NewTicker(i.Cfg.HealthCheckPeriod)
 	for {
 		select {
-		case <-ticker.C:
-			i.health(ctx)
 		case <-ctx.Done():
 			return
+		case <-ticker.C:
+			i.health(ctx)
 		}
 	}
 }


### PR DESCRIPTION
(Issue #236)

The file Output sends all writes immediately to File.Write() which will block until output is written regardless of context.Context being "done". This changes the behavior to limit calls to File.Write() to a `ConcurrencyLimit` specified in file.Config. The default limit is 1000.