### PR TITLE
upgrade version + improved install script

### DIFF
--- a/cmd/versionUpgrade.go
+++ b/cmd/versionUpgrade.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var downloadURL = "https://github.com/karimra/gnmic/raw/master/install.sh"
+
+// upgradeCmd represents the version command
+var upgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "upgrade gnmic to latest available version",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		f, err := ioutil.TempFile("", "gnmic")
+		defer os.Remove(f.Name())
+		if err != nil {
+			log.Fatalf("Failed to create temp file %s\n", err)
+		}
+		downloadFile(downloadURL, f)
+
+		c := exec.Command("bash", f.Name())
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		err = c.Run()
+		if err != nil {
+			log.Fatalf("Upgrade failed: %s\n", err)
+		}
+	},
+}
+
+// downloadFile will download a file from a URL and write its content to a file
+func downloadFile(url string, file *os.File) error {
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Write the body to file
+	_, err = io.Copy(file, resp.Body)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	versionCmd.AddCommand(upgradeCmd)
+}

--- a/cmd/versionUpgrade.go
+++ b/cmd/versionUpgrade.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var downloadURL = "https://github.com/karimra/gnmic/raw/master/install.sh"
@@ -29,7 +30,14 @@ var upgradeCmd = &cobra.Command{
 			return err
 		}
 
-		c := exec.Command("bash", f.Name())
+		var c *exec.Cmd
+		switch viper.GetBool("upgrade-use-pkg") {
+		case true:
+			c = exec.Command("bash", f.Name(), "--use-pkg")
+		case false:
+			c = exec.Command("bash", f.Name())
+		}
+
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
 		err = c.Run()
@@ -60,4 +68,6 @@ func downloadFile(url string, file *os.File) error {
 
 func init() {
 	versionCmd.AddCommand(upgradeCmd)
+	upgradeCmd.Flags().Bool("use-pkg", false, "upgrade using package")
+	viper.BindPFlag("upgrade-use-pkg", upgradeCmd.LocalFlags().Lookup("use-pkg"))
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,28 @@ version : 0.0.3
 Installation complete!
 ```
 
-To upgrade the tool run the installation script once again, it will perform the upgrade if a newer version is available.
+To install a specific version of `gnmic`, provide the version with `-v` flag to the installation script:
+```bash
+sudo curl -sL https://github.com/karimra/gnmic/raw/master/install.sh | sudo bash -s -- -v 0.5.0
+```
+
+#### Packages
+Linux users running distributives with support for `deb`/`rpm` packages can install `gnmic` using pre-built packages:
+
+```
+sudo curl -sL https://github.com/karimra/gnmic/raw/master/install.sh | sudo bash -s -- --use-pkg
+```
+
+#### Upgrade
+
+To upgrade `gnmic` to the latest version use the `upgrade` command:
+```bash
+# upgrade using binary file
+gnmic version upgrade
+
+# upgrade using package
+gnmic version upgrade --use-pkg
+```
 
 ### Windows
 Windows users should use [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) on Windows and install the linux version of the tool.

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ Installation complete!
 To upgrade the tool run the installation script once again, it will perform the upgrade if a newer version is available.
 
 ### Windows
-It is highly recommended to use [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) on Windows, but if its not possible, use [releases page](https://github.com/karimra/gnmic/releases) to download the windows executable file.
+Windows users should use [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) on Windows and install the linux version of the tool.
 
 ### Docker
 The `gnmic` Dockerfile is [provided](https://github.com/karimra/gnmic/blob/master/Dockerfile) within the repository for a manual build process. Later the ready-made docker image will be part of the release pipeline and you will be able to pull the image from the docker hub.


### PR DESCRIPTION
1. added `gnmic version upgrade` command
2. removed hardcoded strings in the installation script and made `--use-pkg` flag that will be able to fetch the package and install it instead of using tar.gz archive

close #151 