### PR TITLE
add config watch to subscribe cmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/karimra/gnmic/collector"
 	"github.com/karimra/gnmic/config"
 	"github.com/karimra/gnmic/formatters"
@@ -82,6 +83,7 @@ var formats = [][2]string{
 var tlsVersions = []string{"1.3", "1.2", "1.1", "1.0", "1"}
 
 type CLI struct {
+	m         *sync.Mutex
 	config    *config.Config
 	collector *collector.Collector
 	logger    *log.Logger
@@ -95,6 +97,7 @@ type CLI struct {
 }
 
 var cli = &CLI{
+	m:             new(sync.Mutex),
 	config:        config.New(),
 	logger:        log.New(ioutil.Discard, "", log.LstdFlags),
 	promptHistory: make([]string, 0, 128),
@@ -431,4 +434,56 @@ func printCapResponse(printPrefix string, msg *gnmi.CapabilityResponse) {
 		sb.WriteString("\n")
 	}
 	fmt.Printf("%s\n", indent(printPrefix, sb.String()))
+}
+
+func (c *CLI) watchConfig() {
+	c.config.FileConfig.OnConfigChange(c.loadTargets)
+	c.config.FileConfig.WatchConfig()
+}
+
+func (c *CLI) loadTargets(e fsnotify.Event) {
+	c.logger.Printf("got config change notification: %v", e)
+	c.m.Lock()
+	defer c.m.Unlock()
+	switch e.Op {
+	case fsnotify.Write, fsnotify.Create:
+		err := c.config.FileConfig.ReadInConfig()
+		if err != nil {
+			c.logger.Printf("failed reading new config: %v", err)
+			return
+		}
+
+		err = c.config.FileConfig.Unmarshal(c.config.FileConfig)
+		if err != nil {
+			c.logger.Printf("failed to unmarshal new config: %v", err)
+			return
+		}
+		newTargets, err := c.config.GetTargets()
+		if err != nil && !errors.Is(err, config.ErrNoTargetsFound) {
+			c.logger.Printf("failed getting targets from new config: %v", err)
+			return
+		}
+		currentTargets := c.collector.Targets
+		// delete targets
+		for n := range currentTargets {
+			if _, ok := newTargets[n]; !ok {
+				err = c.collector.DeleteTarget(n)
+				if err != nil {
+					c.logger.Printf("failed to delete target %q: %v", n, err)
+				}
+			}
+		}
+		// add targets
+		for n, tc := range newTargets {
+			if _, ok := currentTargets[n]; !ok {
+				err = c.collector.AddTarget(tc)
+				if err != nil {
+					c.logger.Printf("failed adding target %q: %v", n, err)
+					continue
+				}
+				c.wg.Add(1)
+				go c.subscribe(gctx, tc)
+			}
+		}
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -447,17 +447,6 @@ func (c *CLI) loadTargets(e fsnotify.Event) {
 	defer c.m.Unlock()
 	switch e.Op {
 	case fsnotify.Write, fsnotify.Create:
-		err := c.config.FileConfig.ReadInConfig()
-		if err != nil {
-			c.logger.Printf("failed reading new config: %v", err)
-			return
-		}
-
-		err = c.config.FileConfig.Unmarshal(c.config.FileConfig)
-		if err != nil {
-			c.logger.Printf("failed to unmarshal new config: %v", err)
-			return
-		}
 		newTargets, err := c.config.GetTargets()
 		if err != nil && !errors.Is(err, config.ErrNoTargetsFound) {
 			c.logger.Printf("failed getting targets from new config: %v", err)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -335,12 +335,6 @@ func (c *Collector) Start(ctx context.Context) {
 		}
 	}()
 
-	go func() {
-		for _, t := range c.Targets {
-			c.targetsChan <- t
-		}
-	}()
-
 	for t := range c.targetsChan {
 		c.logger.Printf("starting target %q listener", t.Config.Name)
 		go func(t *Target) {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -48,6 +48,8 @@ type Collector struct {
 	logger                *log.Logger
 	httpServer            *http.Server
 	reg                   *prometheus.Registry
+
+	targetsChan chan *Target
 }
 
 type CollectorOption func(c *Collector)
@@ -99,11 +101,12 @@ func NewCollector(config *Config, targetConfigs map[string]*TargetConfig, opts .
 	}
 
 	c := &Collector{
-		Config:     config,
-		m:          new(sync.Mutex),
-		Targets:    make(map[string]*Target),
-		Outputs:    make(map[string]outputs.Output),
-		httpServer: httpServer,
+		Config:      config,
+		m:           new(sync.Mutex),
+		Targets:     make(map[string]*Target),
+		Outputs:     make(map[string]outputs.Output),
+		httpServer:  httpServer,
+		targetsChan: make(chan *Target),
 	}
 	for _, op := range opts {
 		op(c)
@@ -126,7 +129,6 @@ func NewCollector(config *Config, targetConfigs map[string]*TargetConfig, opts .
 		}
 		c.dialOpts = append(c.dialOpts, grpc.WithStreamInterceptor(grpcMetrics.StreamClientInterceptor()))
 	}
-
 	for _, tc := range targetConfigs {
 		c.AddTarget(tc)
 	}
@@ -164,6 +166,10 @@ func (c *Collector) AddTarget(tc *TargetConfig) error {
 	c.m.Lock()
 	defer c.m.Unlock()
 	c.Targets[t.Config.Name] = t
+	go func() {
+		c.logger.Printf("queuing target %q", t.Config.Name)
+		c.targetsChan <- t
+	}()
 	return nil
 }
 
@@ -172,12 +178,14 @@ func (c *Collector) DeleteTarget(name string) error {
 		return nil
 	}
 	if _, ok := c.Targets[name]; !ok {
-		return fmt.Errorf("target '%s' does not exist", name)
+		return fmt.Errorf("target '%q' does not exist", name)
 	}
 	c.m.Lock()
 	defer c.m.Unlock()
+	c.logger.Printf("deleting target %q", name)
 	t := c.Targets[name]
 	t.Stop()
+	delete(c.Targets, name)
 	return nil
 }
 
@@ -326,11 +334,16 @@ func (c *Collector) Start(ctx context.Context) {
 			o.Close()
 		}
 	}()
-	wg := new(sync.WaitGroup)
-	wg.Add(len(c.Targets))
-	for _, t := range c.Targets {
+
+	go func() {
+		for _, t := range c.Targets {
+			c.targetsChan <- t
+		}
+	}()
+
+	for t := range c.targetsChan {
+		c.logger.Printf("starting target %q listener", t.Config.Name)
 		go func(t *Target) {
-			defer wg.Done()
 			numOnceSubscriptions := t.numberOfOnceSubscriptions()
 			remainingOnceSubscriptions := numOnceSubscriptions
 			numSubscriptions := len(t.Subscriptions)
@@ -372,13 +385,18 @@ func (c *Collector) Start(ctx context.Context) {
 					if remainingOnceSubscriptions == 0 && numSubscriptions == numOnceSubscriptions {
 						return
 					}
+				case <-t.stopChan:
+					c.logger.Printf("stopping target %q listener", t.Config.Name)
+					return
 				case <-ctx.Done():
 					return
 				}
 			}
 		}(t)
 	}
-	wg.Wait()
+	for range ctx.Done() {
+		return
+	}
 }
 
 // TargetPoll sends a gnmi.SubscribeRequest_Poll to targetName and returns the response and an error,

--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ type LocalFlags struct {
 	SubscribeUpdatesOnly       bool          `mapstructure:"subscribe-updates-only,omitempty" json:"subscribe-updates-only,omitempty" yaml:"subscribe-updates-only,omitempty"`
 	SubscribeMode              string        `mapstructure:"subscribe-mode,omitempty" json:"subscribe-mode,omitempty" yaml:"subscribe-mode,omitempty"`
 	SubscribeStreamMode        string        `mapstructure:"subscribe-stream_mode,omitempty" json:"subscribe-stream-mode,omitempty" yaml:"subscribe-stream-mode,omitempty"`
-	SubscribeSampleInteral     time.Duration `mapstructure:"subscribe-sample-interal,omitempty" json:"subscribe-sample-interal,omitempty" yaml:"subscribe-sample-interal,omitempty"`
+	SubscribeSampleInterval     time.Duration `mapstructure:"subscribe-sample-interval,omitempty" json:"subscribe-sample-interval,omitempty" yaml:"subscribe-sample-interval,omitempty"`
 	SubscribeSuppressRedundant bool          `mapstructure:"subscribe-suppress-redundant,omitempty" json:"subscribe-suppress-redundant,omitempty" yaml:"subscribe-suppress-redundant,omitempty"`
 	SubscribeHeartbearInterval time.Duration `mapstructure:"subscribe-heartbear-interval,omitempty" json:"subscribe-heartbear-interval,omitempty" yaml:"subscribe-heartbear-interval,omitempty"`
 	SubscribeModel             []string      `mapstructure:"subscribe-model,omitempty" json:"subscribe-model,omitempty" yaml:"subscribe-model,omitempty"`
@@ -102,6 +102,7 @@ type LocalFlags struct {
 	SubscribeTarget            string        `mapstructure:"subscribe-target,omitempty" json:"subscribe-target,omitempty" yaml:"subscribe-target,omitempty"`
 	SubscribeName              []string      `mapstructure:"subscribe-name,omitempty" json:"subscribe-name,omitempty" yaml:"subscribe-name,omitempty"`
 	SubscribeOutput            []string      `mapstructure:"subscribe-output,omitempty" json:"subscribe-output,omitempty" yaml:"subscribe-output,omitempty"`
+	SubscribeWatchConfig       bool          `mapstructure:"subscribe-watch-config,omitempty" json:"subscribe-watch-config,omitempty" yaml:"subscribe-watch-config,omitempty"`
 	// Path
 	PathFile       []string `mapstructure:"path-file,omitempty" json:"path-file,omitempty" yaml:"path-file,omitempty"`
 	PathExclude    []string `mapstructure:"path-exclude,omitempty" json:"path-exclude,omitempty" yaml:"path-exclude,omitempty"`
@@ -518,7 +519,8 @@ func readFile(name string) ([]byte, error) {
 		return nil, fmt.Errorf("unsupported file format %s", filepath.Ext(name))
 	}
 }
-// SanitizeArrayFlagValue trims trailing and leading brackets ([]), 
+
+// SanitizeArrayFlagValue trims trailing and leading brackets ([]),
 // from each of ls elements only if both are present.
 func SanitizeArrayFlagValue(ls []string) []string {
 	res := make([]string, 0, len(ls))

--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ type LocalFlags struct {
 	SubscribeUpdatesOnly       bool          `mapstructure:"subscribe-updates-only,omitempty" json:"subscribe-updates-only,omitempty" yaml:"subscribe-updates-only,omitempty"`
 	SubscribeMode              string        `mapstructure:"subscribe-mode,omitempty" json:"subscribe-mode,omitempty" yaml:"subscribe-mode,omitempty"`
 	SubscribeStreamMode        string        `mapstructure:"subscribe-stream_mode,omitempty" json:"subscribe-stream-mode,omitempty" yaml:"subscribe-stream-mode,omitempty"`
-	SubscribeSampleInterval     time.Duration `mapstructure:"subscribe-sample-interval,omitempty" json:"subscribe-sample-interval,omitempty" yaml:"subscribe-sample-interval,omitempty"`
+	SubscribeSampleInterval    time.Duration `mapstructure:"subscribe-sample-interval,omitempty" json:"subscribe-sample-interval,omitempty" yaml:"subscribe-sample-interval,omitempty"`
 	SubscribeSuppressRedundant bool          `mapstructure:"subscribe-suppress-redundant,omitempty" json:"subscribe-suppress-redundant,omitempty" yaml:"subscribe-suppress-redundant,omitempty"`
 	SubscribeHeartbearInterval time.Duration `mapstructure:"subscribe-heartbear-interval,omitempty" json:"subscribe-heartbear-interval,omitempty" yaml:"subscribe-heartbear-interval,omitempty"`
 	SubscribeModel             []string      `mapstructure:"subscribe-model,omitempty" json:"subscribe-model,omitempty" yaml:"subscribe-model,omitempty"`

--- a/config/subscriptions.go
+++ b/config/subscriptions.go
@@ -32,7 +32,7 @@ func (c *Config) GetSubscriptions(cmd *cobra.Command) (map[string]*collector.Sub
 			sub.HeartbeatInterval = &c.LocalFlags.SubscribeHeartbearInterval
 		}
 		if flagIsSet(cmd, "sample-interval") {
-			sub.SampleInterval = &c.LocalFlags.SubscribeSampleInteral
+			sub.SampleInterval = &c.LocalFlags.SubscribeSampleInterval
 		}
 		sub.SuppressRedundant = c.LocalFlags.SubscribeSuppressRedundant
 		sub.UpdatesOnly = c.LocalFlags.SubscribeUpdatesOnly
@@ -94,7 +94,7 @@ func (c *Config) GetSubscriptions(cmd *cobra.Command) (map[string]*collector.Sub
 func (c *Config) setSubscriptionDefaults(sub *collector.SubscriptionConfig, cmd *cobra.Command) {
 	if sub.SampleInterval == nil {
 		if flagIsSet(cmd, "sample-interval") {
-			sub.SampleInterval = &c.LocalFlags.SubscribeSampleInteral
+			sub.SampleInterval = &c.LocalFlags.SubscribeSampleInterval
 		}
 	}
 	if sub.HeartbeatInterval == nil {

--- a/config/targets.go
+++ b/config/targets.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+var ErrNoTargetsFound = errors.New("no targets found")
+
 func (c *Config) GetTargets() (map[string]*collector.TargetConfig, error) {
 	targets := make(map[string]*collector.TargetConfig)
 	defGrpcPort := c.FileConfig.GetString("port")
@@ -66,12 +68,12 @@ func (c *Config) GetTargets() (map[string]*collector.TargetConfig, error) {
 	case map[string]interface{}:
 		targetsMap = targetsInt
 	case nil:
-		return nil, errors.New("no targets found")
+		return nil, ErrNoTargetsFound
 	default:
 		return nil, fmt.Errorf("unexpected targets format, got: %T", targetsInt)
 	}
 	if len(targetsMap) == 0 {
-		return nil, fmt.Errorf("no targets found")
+		return nil, ErrNoTargetsFound
 	}
 	for addr, t := range targetsMap {
 		if !strings.HasPrefix(addr, "unix://") {

--- a/docs/cmd/subscribe.md
+++ b/docs/cmd/subscribe.md
@@ -87,6 +87,11 @@ The `[--output]` flag is used to select one or multiple output already defined i
 
 Outputs defined under target take precedence over this flag, see [defining outputs](../advanced/multi_outputs/output_intro.md) and [defining targets](../advanced/multi_targets)
 
+#### watch-config
+The `[--watch-config]` flag is used to enable automatic target loading from the configuration source at runtime. 
+
+On each configuration change, gnmic reloads the list of targets, subscribes to new targets and/or deletes subscriptions to the deleted ones
+
 ### Examples
 #### 1. streaming, target-defined, 10s interval
 ```bash

--- a/docs/cmd/subscribe.md
+++ b/docs/cmd/subscribe.md
@@ -90,7 +90,9 @@ Outputs defined under target take precedence over this flag, see [defining outpu
 #### watch-config
 The `[--watch-config]` flag is used to enable automatic target loading from the configuration source at runtime. 
 
-On each configuration change, gnmic reloads the list of targets, subscribes to new targets and/or deletes subscriptions to the deleted ones
+On each configuration change, gnmic reloads the list of targets, subscribes to new targets and/or deletes subscriptions to the deleted ones.
+
+Only addition and deletion of targets are currently supported, changes in an existing target config are not possible.
 
 ### Examples
 #### 1. streaming, target-defined, 10s interval

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/Shopify/sarama v1.26.4
 	github.com/c-bata/go-prompt v0.2.5
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/google/gnxi v0.0.0-20200508145201-92c6d0d3ec3b
 	github.com/google/go-cmp v0.5.0
 	github.com/google/uuid v1.1.1


### PR DESCRIPTION
This PR adds support for target loading during runtime.
If the flag `--watch-config` is used, a watch is added on the config file directory ( via viper ).
For each fsnotify event received (create/write) the targets configuration is read again, and compared to the current one.
New targets are added to the collector, removed targets are deleted from the collector and their active subscriptions are stopped.