### PR TITLE
modify default configuration file placement

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,17 +13,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/adrg/xdg"
 	"github.com/karimra/gnmic/collector"
 	"github.com/mitchellh/go-homedir"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const (
-	configName      = "gnmic"
+	configName      = ".gnmic"
 	configLogPrefix = "[config] "
 )
 
@@ -154,6 +155,9 @@ func (c *Config) Load(file string) error {
 			return err
 		}
 		c.FileConfig.AddConfigPath(home)
+		c.FileConfig.AddConfigPath(".")
+		c.FileConfig.AddConfigPath(xdg.ConfigHome)
+		c.FileConfig.AddConfigPath(xdg.ConfigHome + "/gnmic")
 		c.FileConfig.SetConfigName(configName)
 	}
 
@@ -169,6 +173,7 @@ func (c *Config) Load(file string) error {
 
 	return nil
 }
+
 
 func (c *Config) SetLogger() {
 	if c.Globals.LogFile != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -154,8 +154,8 @@ func (c *Config) Load(file string) error {
 		if err != nil {
 			return err
 		}
-		c.FileConfig.AddConfigPath(home)
 		c.FileConfig.AddConfigPath(".")
+		c.FileConfig.AddConfigPath(home)
 		c.FileConfig.AddConfigPath(xdg.ConfigHome)
 		c.FileConfig.AddConfigPath(xdg.ConfigHome + "/gnmic")
 		c.FileConfig.SetConfigName(configName)
@@ -173,7 +173,6 @@ func (c *Config) Load(file string) error {
 
 	return nil
 }
-
 
 func (c *Config) SetLogger() {
 	if c.Globals.LogFile != "" {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/Shopify/sarama v1.26.4
+	github.com/adrg/xdg v0.3.0
 	github.com/c-bata/go-prompt v0.2.5
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/google/gnxi v0.0.0-20200508145201-92c6d0d3ec3b

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/Shopify/sarama v1.26.4 h1:+17TxUq/PJEAfZAll0T7XJjSgQWCpaQSoki/x5yN8o8
 github.com/Shopify/sarama v1.26.4/go.mod h1:NbSGBSSndYaIhRcBtY9V0U7AyH+x71bG668AuWys/yU=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/adrg/xdg v0.3.0 h1:BO+k4wFj0IoTolBF1Apn8oZrX3LQrEbBA8+/9vyW9J4=
+github.com/adrg/xdg v0.3.0/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
i love this tool, wonderfully done!  i just found myself making the one-line patch to change the default configuration file to a dotfile that resides in my home directory.  i realize it's a highly personal thing, i just don't like to have configuration files unhidden, and cluttering up my home directory.  also, i blew my `gnmic.yaml` file out accidentally a few times. 😢 

this PR does the following:
- changes the default `gnmic.[toml,yaml,json]` file to `.gnmic.*` as appropriate (to hide from directory listing) 
- allows placement within the following configuration file locations:
  - `$HOME/.gnmic.yaml`
  - `$XDG_CONFIG_HOME/.gnmic.yaml`
  - `$XDG_CONFIG_HOME/gnmic/.gnmic.yaml`