### PR TITLE
convert gnmi.Decimal64 to float for prometheus

### DIFF
--- a/outputs/prometheus_output/prometheus_output.go
+++ b/outputs/prometheus_output/prometheus_output.go
@@ -519,6 +519,8 @@ func getFloat(v interface{}) (float64, error) {
 			return math.NaN(), err
 		}
 		return f, err
+	case *gnmi.Decimal64:
+		return float64(i.Digits) / math.Pow10(int(i.Precision)), nil
 	default:
 		return math.NaN(), errors.New("getFloat: unknown value is of incompatible type")
 	}


### PR DESCRIPTION
If the target returns data of gnmi.Decimal64 data type, the prometheus output will not export this as it does no convert it to a float as required by prometheus. Thus, this PR calculates the float value for any gnmi.Decimal64 so it can be exported accordingly.

I realize that this PR only implements this for the prometheus output and none other, but it is a trivial change so I think it is reasonable to have this.