### PR TITLE
fix name of event-extract-tags processor

### DIFF
--- a/docs/user_guide/event_processors/event_extract_tags.md
+++ b/docs/user_guide/event_processors/event_extract_tags.md
@@ -1,4 +1,4 @@
-The `event-extract-tag` processor, extracts tags from a value, a value name, a tag name or a tag value using regex named groups.
+The `event-extract-tags` processor, extracts tags from a value, a value name, a tag name or a tag value using regex named groups.
 
 It is possible to overwrite a tag if its name already exists.
 
@@ -29,7 +29,7 @@ processors:
   # processor name
   sample-processor:
     # processor type
-    event-extract-tag:
+    event-extract-tags:
       value-names:
         - `/(\w+)/(?P<group>\w+)/(\w+)`
 ```

--- a/formatters/event_extract_tags/event_extract_tags.go
+++ b/formatters/event_extract_tags/event_extract_tags.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	processorType = "event-extract-tag"
+	processorType = "event-extract-tags"
 	loggingPrefix = "[" + processorType + "] "
 )
 


### PR DESCRIPTION
The event-extract-tags processor does not work because its name is inconsistent.
```
[influxdb_output] 2021/07/26 11:05:54.705970 "sample-processor" event processor has an unknown type="event-extract-tags"
```