### PR TITLE
Add capability to convert Binary Float Representation to Float

### DIFF
--- a/formatters/event_convert/event_convert.go
+++ b/formatters/event_convert/event_convert.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"math"
+	"encoding/binary"
+	"reflect"
 
 	"github.com/karimra/gnmic/formatters"
 	"github.com/karimra/gnmic/types"
@@ -220,7 +223,11 @@ func convertToUint(i interface{}) (uint, error) {
 }
 
 func convertToFloat(i interface{}) (float64, error) {
+	fmt.Println(reflect.TypeOf(i))
 	switch i := i.(type) {
+	case []uint8:
+	  ij := math.Float32frombits(binary.BigEndian.Uint32([]byte(i)))
+	  return float64(float32(ij)), nil
 	case string:
 		iv, err := strconv.ParseFloat(i, 64)
 		if err != nil {

--- a/formatters/event_convert/event_convert.go
+++ b/formatters/event_convert/event_convert.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"math"
 	"encoding/binary"
-	"reflect"
 
 	"github.com/karimra/gnmic/formatters"
 	"github.com/karimra/gnmic/types"
@@ -223,7 +222,6 @@ func convertToUint(i interface{}) (uint, error) {
 }
 
 func convertToFloat(i interface{}) (float64, error) {
-	fmt.Println(reflect.TypeOf(i))
 	switch i := i.(type) {
 	case []uint8:
 	  ij := math.Float32frombits(binary.BigEndian.Uint32([]byte(i)))

--- a/formatters/event_convert/event_convert.go
+++ b/formatters/event_convert/event_convert.go
@@ -224,7 +224,13 @@ func convertToUint(i interface{}) (uint, error) {
 func convertToFloat(i interface{}) (float64, error) {
 	switch i := i.(type) {
 	case []uint8:
-	  ij := math.Float32frombits(binary.BigEndian.Uint32([]byte(i)))
+		if len(i) == 4 {
+	  	ij := math.Float32frombits(binary.BigEndian.Uint32([]byte(i)))
+		} else if len(i) == 8 {
+			ij := math.Float64frombits(binary.BigEndian.Uint64([]byte(i)))
+		} else {
+			return 0, nil
+		}
 	  return float64(ij), nil
 	case string:
 		iv, err := strconv.ParseFloat(i, 64)

--- a/formatters/event_convert/event_convert.go
+++ b/formatters/event_convert/event_convert.go
@@ -225,13 +225,12 @@ func convertToFloat(i interface{}) (float64, error) {
 	switch i := i.(type) {
 	case []uint8:
 		if len(i) == 4 {
-	  	ij := math.Float32frombits(binary.BigEndian.Uint32([]byte(i)))
+	  	return float64(math.Float32frombits(binary.BigEndian.Uint32([]byte(i)))), nil
 		} else if len(i) == 8 {
-			ij := math.Float64frombits(binary.BigEndian.Uint64([]byte(i)))
+			return float64(math.Float64frombits(binary.BigEndian.Uint64([]byte(i)))), nil
 		} else {
 			return 0, nil
 		}
-	  return float64(ij), nil
 	case string:
 		iv, err := strconv.ParseFloat(i, 64)
 		if err != nil {

--- a/formatters/event_convert/event_convert.go
+++ b/formatters/event_convert/event_convert.go
@@ -225,7 +225,7 @@ func convertToFloat(i interface{}) (float64, error) {
 	switch i := i.(type) {
 	case []uint8:
 	  ij := math.Float32frombits(binary.BigEndian.Uint32([]byte(i)))
-	  return float64(float32(ij)), nil
+	  return float64(ij), nil
 	case string:
 		iv, err := strconv.ParseFloat(i, 64)
 		if err != nil {

--- a/formatters/event_convert/event_convert_test.go
+++ b/formatters/event_convert/event_convert_test.go
@@ -437,6 +437,42 @@ var testset = map[string]struct {
 			{
 				input: []*formatters.EventMsg{
 					{
+						Values: map[string]interface{}{"number": []uint8{64, 9, 33, 251, 84, 68, 45, 24}},
+					},
+				},
+				output: []*formatters.EventMsg{
+					{
+						Values: map[string]interface{}{"number": float64(3.141592653589793)},
+					},
+				},
+			},
+			{
+				input: []*formatters.EventMsg{
+					{
+						Values: map[string]interface{}{"number": []uint8{64, 9, 33, 251, 84, 68, 45, 24, 32}},
+					},
+				},
+				output: []*formatters.EventMsg{
+					{
+						Values: map[string]interface{}{"number": float64(0)},
+					},
+				},
+			},
+			{
+				input: []*formatters.EventMsg{
+					{
+						Values: map[string]interface{}{"number": []uint8{62, 192, 0, 0}},
+					},
+				},
+				output: []*formatters.EventMsg{
+					{
+						Values: map[string]interface{}{"number": float64(0.375)},
+					},
+				},
+			},
+			{
+				input: []*formatters.EventMsg{
+					{
 						Values: map[string]interface{}{"number": "1.1"},
 					},
 				},

--- a/formatters/event_convert/event_convert_test.go
+++ b/formatters/event_convert/event_convert_test.go
@@ -425,6 +425,18 @@ var testset = map[string]struct {
 			{
 				input: []*formatters.EventMsg{
 					{
+						Values: map[string]interface{}{"number": []uint8{62, 192, 0, 0}},
+					},
+				},
+				output: []*formatters.EventMsg{
+					{
+						Values: map[string]interface{}{"number": float64(0.375)},
+					},
+				},
+			},
+			{
+				input: []*formatters.EventMsg{
+					{
 						Values: map[string]interface{}{"number": "1.1"},
 					},
 				},


### PR DESCRIPTION
Hello,

Thank for your project.
I have added the capability to convert IEEE Float from the openconfig typedef to float64.
It's typically used by Arista for Current and Voltage of Power Supplies.

typedef ieeefloat32 {
type binary {
length "4";
}
description
"An IEEE 32-bit floating point number. The format of this number
is of the form:
1-bit sign
8-bit exponent
23-bit fraction
The floating point value is calculated using:
(-1)S * 2(Exponent-127) * (1+Fraction)";
}

Thanks