### PR TITLE
Set logger to discard by default and use value in the config file

### DIFF
--- a/formatters/event_override_ts/event_override_ts.go
+++ b/formatters/event_override_ts/event_override_ts.go
@@ -29,7 +29,7 @@ type OverrideTS struct {
 func init() {
 	formatters.Register(processorType, func() formatters.EventProcessor {
 		return &OverrideTS{
-			logger: log.New(os.Stderr, "", 0),
+			logger: log.New(ioutil.Discard, "", 0),
 		}
 	})
 }


### PR DESCRIPTION
Hello,

When the log and debug option are set to false. Event Override TS continue to log on stderr.
Fix the init of the event_override.

Regards.