### PR TITLE
implement WriteEvent in InfluxDBOutput

### DIFF
--- a/outputs/influxdb_output/influxdb_output.go
+++ b/outputs/influxdb_output/influxdb_output.go
@@ -213,7 +213,15 @@ func (i *InfluxDBOutput) Write(ctx context.Context, rsp proto.Message, meta outp
 	}
 }
 
-func (i *InfluxDBOutput) WriteEvent(ctx context.Context, ev *formatters.EventMsg) {}
+func (i *InfluxDBOutput) WriteEvent(ctx context.Context, ev *formatters.EventMsg) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-i.reset:
+		return
+	case i.eventChan <- ev:
+	}
+}
 
 func (i *InfluxDBOutput) Close() error {
 	i.logger.Printf("closing client...")


### PR DESCRIPTION
Currently WriteEvent is not implemented in InfluxDBOutput, so in a pipeline setup no events are written to InfluxDB.
This commit copies the select block from Write to fix this.