### PR TITLE
replace gomplate' `hasKey` with `has`

### DIFF
--- a/docs/cmd/set.md
+++ b/docs/cmd/set.md
@@ -330,12 +330,12 @@ replaces:
       subinterface:
         - index: {{ $index }}
           admin-state: {{ index $subinterface "admin-state" | default "disable" }}
-          {{- if hasKey $subinterface "ipv4-address" }}
+          {{- if has $subinterface "ipv4-address" }}
           ipv4:
             address:
               - ip-prefix: {{ index $subinterface "ipv4-address" | toString }}
           {{- end }}
-          {{- if hasKey $subinterface "ipv6-address" }}
+          {{- if has $subinterface "ipv6-address" }}
           ipv6:
             address:
               - ip-prefix: {{ index $subinterface "ipv6-address" | toString }}


### PR DESCRIPTION
Looks like `hasKey` was something from the old versions of gomplate, now it is simply `has` - https://docs.gomplate.ca/functions/coll/#coll-has

otherwise the following error renders:

```
gomplate -f mac-vrf.gotmpl -d mac-vrf_vars.gotmpl.yml
10:46:22 ERR error="failed to render template mac-vrf.gotmpl: template: mac-vrf.gotmpl:13: function \"hasKey\" not defined"
``` 