### PR TITLE
fix appending of options for `--update-file` and `--replace-file` flags

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -602,8 +602,8 @@ func (c *Config) CreateSetRequest(targetName string) ([]*gnmi.SetRequest, error)
 				api.Path(strings.TrimSpace(p)),
 				api.Value(c.LocalFlags.SetUpdateValue[i], c.Encoding),
 			)
-			gnmiOpts = append(gnmiOpts, updOpt)
 		}
+		gnmiOpts = append(gnmiOpts, updOpt)
 	}
 
 	for i, p := range c.LocalFlags.SetReplacePath {
@@ -624,8 +624,8 @@ func (c *Config) CreateSetRequest(targetName string) ([]*gnmi.SetRequest, error)
 				api.Path(strings.TrimSpace(p)),
 				api.Value(c.LocalFlags.SetReplaceValue[i], c.Encoding),
 			)
-			gnmiOpts = append(gnmiOpts, replaceOpt)
 		}
+		gnmiOpts = append(gnmiOpts, replaceOpt)
 	}
 
 	req, err := api.NewSetRequest(gnmiOpts...)


### PR DESCRIPTION
The append should be done outside of the else block.

This is fixes #557.