### PR TITLE
Added support to also generate paths of YANG containers

### DIFF
--- a/app/generatePath.go
+++ b/app/generatePath.go
@@ -25,15 +25,15 @@ func (a *App) GeneratePathRunE(cmd *cobra.Command, args []string) error {
 		a.Config.GlobalFlags.File,
 		a.Config.GlobalFlags.Exclude,
 		pathGenOpts{
-			search:         a.Config.LocalFlags.GeneratePathSearch,
-			withDescr:      a.Config.LocalFlags.GeneratePathWithDescr,
-			withTypes:      a.Config.LocalFlags.GeneratePathWithTypes,
-			withPrefix:     a.Config.LocalFlags.GeneratePathWithPrefix,
-			pathType:       a.Config.LocalFlags.GeneratePathPathType,
-			stateOnly:      a.Config.LocalFlags.GeneratePathState,
-			configOnly:     a.Config.LocalFlags.GeneratePathConfig,
-			json:           a.Config.LocalFlags.GenerateJSON,
-			withContainers: a.Config.LocalFlags.GeneratePathWithContainers,
+			search:        a.Config.LocalFlags.GeneratePathSearch,
+			withDescr:     a.Config.LocalFlags.GeneratePathWithDescr,
+			withTypes:     a.Config.LocalFlags.GeneratePathWithTypes,
+			withPrefix:    a.Config.LocalFlags.GeneratePathWithPrefix,
+			pathType:      a.Config.LocalFlags.GeneratePathPathType,
+			stateOnly:     a.Config.LocalFlags.GeneratePathState,
+			configOnly:    a.Config.LocalFlags.GeneratePathConfig,
+			json:          a.Config.LocalFlags.GenerateJSON,
+			withNonLeaves: a.Config.LocalFlags.GeneratePathWithNonLeaves,
 		},
 	)
 }
@@ -47,7 +47,7 @@ func (a *App) InitGeneratePathFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&a.Config.LocalFlags.GeneratePathSearch, "search", "", false, "search through path list")
 	cmd.Flags().BoolVarP(&a.Config.LocalFlags.GeneratePathState, "state-only", "", false, "generate paths only for YANG leafs representing state data")
 	cmd.Flags().BoolVarP(&a.Config.LocalFlags.GeneratePathConfig, "config-only", "", false, "generate paths only for YANG leafs representing config data")
-	cmd.Flags().BoolVarP(&a.Config.LocalFlags.GeneratePathWithContainers, "with-containers", "", false, "also generate paths for containers instead of only for leaves")
+	cmd.Flags().BoolVarP(&a.Config.LocalFlags.GeneratePathWithNonLeaves, "with-non-leaves", "", false, "also generate paths for non-leaf nodes")
 	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
 		a.Config.FileConfig.BindPFlag(fmt.Sprintf("%s-%s", cmd.Name(), flag.Name), flag)
 	})

--- a/app/generatePath.go
+++ b/app/generatePath.go
@@ -25,14 +25,15 @@ func (a *App) GeneratePathRunE(cmd *cobra.Command, args []string) error {
 		a.Config.GlobalFlags.File,
 		a.Config.GlobalFlags.Exclude,
 		pathGenOpts{
-			search:     a.Config.LocalFlags.GeneratePathSearch,
-			withDescr:  a.Config.LocalFlags.GeneratePathWithDescr,
-			withTypes:  a.Config.LocalFlags.GeneratePathWithTypes,
-			withPrefix: a.Config.LocalFlags.GeneratePathWithPrefix,
-			pathType:   a.Config.LocalFlags.GeneratePathPathType,
-			stateOnly:  a.Config.LocalFlags.GeneratePathState,
-			configOnly: a.Config.LocalFlags.GeneratePathConfig,
-			json:       a.Config.LocalFlags.GenerateJSON,
+			search:         a.Config.LocalFlags.GeneratePathSearch,
+			withDescr:      a.Config.LocalFlags.GeneratePathWithDescr,
+			withTypes:      a.Config.LocalFlags.GeneratePathWithTypes,
+			withPrefix:     a.Config.LocalFlags.GeneratePathWithPrefix,
+			pathType:       a.Config.LocalFlags.GeneratePathPathType,
+			stateOnly:      a.Config.LocalFlags.GeneratePathState,
+			configOnly:     a.Config.LocalFlags.GeneratePathConfig,
+			json:           a.Config.LocalFlags.GenerateJSON,
+			withContainers: a.Config.LocalFlags.GeneratePathWithContainers,
 		},
 	)
 }
@@ -46,6 +47,7 @@ func (a *App) InitGeneratePathFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&a.Config.LocalFlags.GeneratePathSearch, "search", "", false, "search through path list")
 	cmd.Flags().BoolVarP(&a.Config.LocalFlags.GeneratePathState, "state-only", "", false, "generate paths only for YANG leafs representing state data")
 	cmd.Flags().BoolVarP(&a.Config.LocalFlags.GeneratePathConfig, "config-only", "", false, "generate paths only for YANG leafs representing config data")
+	cmd.Flags().BoolVarP(&a.Config.LocalFlags.GeneratePathWithContainers, "with-containers", "", false, "also generate paths for containers instead of only for leaves")
 	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
 		a.Config.FileConfig.BindPFlag(fmt.Sprintf("%s-%s", cmd.Name(), flag.Name), flag)
 	})

--- a/app/path.go
+++ b/app/path.go
@@ -18,14 +18,15 @@ import (
 )
 
 type pathGenOpts struct {
-	search     bool
-	withDescr  bool
-	withTypes  bool
-	withPrefix bool
-	pathType   string
-	stateOnly  bool
-	configOnly bool
-	json       bool
+	search         bool
+	withDescr      bool
+	withTypes      bool
+	withPrefix     bool
+	pathType       string
+	stateOnly      bool
+	configOnly     bool
+	json           bool
+	withContainers bool
 }
 
 type generatedPath struct {
@@ -65,7 +66,7 @@ func (a *App) PathCmdRun(d, f, e []string, pgo pathGenOpts) error {
 
 	collected := make([]*yang.Entry, 0, 256)
 	for _, entry := range a.SchemaTree.Dir {
-		collected = append(collected, collectSchemaNodes(entry, true)...)
+		collected = append(collected, collectSchemaNodes(entry, !pgo.withContainers)...)
 	}
 	for _, entry := range collected {
 		if !pgo.stateOnly && !pgo.configOnly || pgo.stateOnly && pgo.configOnly {
@@ -257,7 +258,11 @@ func (a *App) generatePath(entry *yang.Entry, pType string) *generatedPath {
 	}
 
 	gp.Description = entry.Description
-	gp.Type = entry.Type.Name
+	if entry.Type != nil {
+		gp.Type = entry.Type.Name
+	} else {
+		gp.Type = "container"
+	}
 
 	if entry.IsLeafList() {
 		gp.Default = strings.Join(entry.DefaultValues(), ", ")

--- a/config/config.go
+++ b/config/config.go
@@ -197,13 +197,14 @@ type LocalFlags struct {
 	GenerateSetRequestUpdatePath  []string `mapstructure:"generate-update-path,omitempty" json:"generate-update-path,omitempty" yaml:"generate-update-path,omitempty"`
 	GenerateSetRequestReplacePath []string `mapstructure:"generate-replace-path,omitempty" json:"generate-replace-path,omitempty" yaml:"generate-replace-path,omitempty"`
 	// Generate path
-	GeneratePathWithDescr  bool   `mapstructure:"generate-descr,omitempty" json:"generate-descr,omitempty" yaml:"generate-descr,omitempty"`
-	GeneratePathWithPrefix bool   `mapstructure:"generate-with-prefix,omitempty" json:"generate-with-prefix,omitempty" yaml:"generate-with-prefix,omitempty"`
-	GeneratePathWithTypes  bool   `mapstructure:"generate-types,omitempty" json:"generate-types,omitempty" yaml:"generate-types,omitempty"`
-	GeneratePathSearch     bool   `mapstructure:"generate-search,omitempty" json:"generate-search,omitempty" yaml:"generate-search,omitempty"`
-	GeneratePathPathType   string `mapstructure:"generate-path-path-type,omitempty" json:"generate-path-path-type,omitempty" yaml:"generate-path-path-type,omitempty"`
-	GeneratePathState      bool   `mapstructure:"generate-path-state,omitempty" json:"generate-path-state,omitempty" yaml:"generate-path-state,omitempty"`
-	GeneratePathConfig     bool   `mapstructure:"generate-path-config,omitempty" json:"generate-path-config,omitempty" yaml:"generate-path-config,omitempty"`
+	GeneratePathWithDescr      bool   `mapstructure:"generate-descr,omitempty" json:"generate-descr,omitempty" yaml:"generate-descr,omitempty"`
+	GeneratePathWithPrefix     bool   `mapstructure:"generate-with-prefix,omitempty" json:"generate-with-prefix,omitempty" yaml:"generate-with-prefix,omitempty"`
+	GeneratePathWithTypes      bool   `mapstructure:"generate-types,omitempty" json:"generate-types,omitempty" yaml:"generate-types,omitempty"`
+	GeneratePathSearch         bool   `mapstructure:"generate-search,omitempty" json:"generate-search,omitempty" yaml:"generate-search,omitempty"`
+	GeneratePathPathType       string `mapstructure:"generate-path-path-type,omitempty" json:"generate-path-path-type,omitempty" yaml:"generate-path-path-type,omitempty"`
+	GeneratePathState          bool   `mapstructure:"generate-path-state,omitempty" json:"generate-path-state,omitempty" yaml:"generate-path-state,omitempty"`
+	GeneratePathConfig         bool   `mapstructure:"generate-path-config,omitempty" json:"generate-path-config,omitempty" yaml:"generate-path-config,omitempty"`
+	GeneratePathWithContainers bool   `mapstructure:"generate-path-with-containers,omitempty" json:"generate-path-with-containers,omitempty" yaml:"generate-path-with-containers,omitempty"`
 	//
 	DiffPath    []string `mapstructure:"diff-path,omitempty" json:"diff-path,omitempty" yaml:"diff-path,omitempty"`
 	DiffPrefix  string   `mapstructure:"diff-prefix,omitempty" json:"diff-prefix,omitempty" yaml:"diff-prefix,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -197,14 +197,14 @@ type LocalFlags struct {
 	GenerateSetRequestUpdatePath  []string `mapstructure:"generate-update-path,omitempty" json:"generate-update-path,omitempty" yaml:"generate-update-path,omitempty"`
 	GenerateSetRequestReplacePath []string `mapstructure:"generate-replace-path,omitempty" json:"generate-replace-path,omitempty" yaml:"generate-replace-path,omitempty"`
 	// Generate path
-	GeneratePathWithDescr      bool   `mapstructure:"generate-descr,omitempty" json:"generate-descr,omitempty" yaml:"generate-descr,omitempty"`
-	GeneratePathWithPrefix     bool   `mapstructure:"generate-with-prefix,omitempty" json:"generate-with-prefix,omitempty" yaml:"generate-with-prefix,omitempty"`
-	GeneratePathWithTypes      bool   `mapstructure:"generate-types,omitempty" json:"generate-types,omitempty" yaml:"generate-types,omitempty"`
-	GeneratePathSearch         bool   `mapstructure:"generate-search,omitempty" json:"generate-search,omitempty" yaml:"generate-search,omitempty"`
-	GeneratePathPathType       string `mapstructure:"generate-path-path-type,omitempty" json:"generate-path-path-type,omitempty" yaml:"generate-path-path-type,omitempty"`
-	GeneratePathState          bool   `mapstructure:"generate-path-state,omitempty" json:"generate-path-state,omitempty" yaml:"generate-path-state,omitempty"`
-	GeneratePathConfig         bool   `mapstructure:"generate-path-config,omitempty" json:"generate-path-config,omitempty" yaml:"generate-path-config,omitempty"`
-	GeneratePathWithContainers bool   `mapstructure:"generate-path-with-containers,omitempty" json:"generate-path-with-containers,omitempty" yaml:"generate-path-with-containers,omitempty"`
+	GeneratePathWithDescr     bool   `mapstructure:"generate-descr,omitempty" json:"generate-descr,omitempty" yaml:"generate-descr,omitempty"`
+	GeneratePathWithPrefix    bool   `mapstructure:"generate-with-prefix,omitempty" json:"generate-with-prefix,omitempty" yaml:"generate-with-prefix,omitempty"`
+	GeneratePathWithTypes     bool   `mapstructure:"generate-types,omitempty" json:"generate-types,omitempty" yaml:"generate-types,omitempty"`
+	GeneratePathSearch        bool   `mapstructure:"generate-search,omitempty" json:"generate-search,omitempty" yaml:"generate-search,omitempty"`
+	GeneratePathPathType      string `mapstructure:"generate-path-path-type,omitempty" json:"generate-path-path-type,omitempty" yaml:"generate-path-path-type,omitempty"`
+	GeneratePathState         bool   `mapstructure:"generate-path-state,omitempty" json:"generate-path-state,omitempty" yaml:"generate-path-state,omitempty"`
+	GeneratePathConfig        bool   `mapstructure:"generate-path-config,omitempty" json:"generate-path-config,omitempty" yaml:"generate-path-config,omitempty"`
+	GeneratePathWithNonLeaves bool   `mapstructure:"generate-path-with-non-leaves,omitempty" json:"generate-path-with-non-leaves,omitempty" yaml:"generate-path-with-non-leaves,omitempty"`
 	//
 	DiffPath    []string `mapstructure:"diff-path,omitempty" json:"diff-path,omitempty" yaml:"diff-path,omitempty"`
 	DiffPrefix  string   `mapstructure:"diff-prefix,omitempty" json:"diff-prefix,omitempty" yaml:"diff-prefix,omitempty"`

--- a/docs/cmd/path.md
+++ b/docs/cmd/path.md
@@ -54,15 +54,15 @@ When the `--descr` flag is present, the leaf description is printed after the pa
 
 #### config-only
 
-When the `--config-only` flag is present, paths are generated only for YANG leafs representing config data.
+When the `--config-only` flag is present, paths are generated only for YANG leaves representing config data.
 
 #### state-only
 
-When the `--state-only` flag is present, paths are generated only for YANG leafs representing state data.
+When the `--state-only` flag is present, paths are generated only for YANG leaves representing state data.
 
-#### with-containers
+#### with-non-leaves
 
-When the `--with-containers` flag is present, paths are generated also for YANG containers instead of only YANG leafs.
+When the `--with-non-leaves` flag is present, paths are generated not only for YANG leaves.
 
 ### Examples
 

--- a/docs/cmd/path.md
+++ b/docs/cmd/path.md
@@ -54,11 +54,15 @@ When the `--descr` flag is present, the leaf description is printed after the pa
 
 #### config-only
 
-When the `--config-only` flag is present, path are generated only for YANG leafs representing config data.
+When the `--config-only` flag is present, paths are generated only for YANG leafs representing config data.
 
 #### state-only
 
-When the `--state-only` flag is present, path are generated only for YANG leafs representing state data.
+When the `--state-only` flag is present, paths are generated only for YANG leafs representing state data.
+
+#### with-containers
+
+When the `--with-containers` flag is present, paths are generated also for YANG containers instead of only YANG leafs.
 
 ### Examples
 


### PR DESCRIPTION
I've added a command flag '--with-containers' to optionally also generate paths for the intermediate container nodes, instead of only generating paths for the leaf nodes.