### PR TITLE
Add event-tags config to targets

### DIFF
--- a/app/collector.go
+++ b/app/collector.go
@@ -69,6 +69,9 @@ func (a *App) StartCollector(ctx context.Context) {
 					if rsp.SubscriptionConfig.Target != "" {
 						m["subscription-target"] = rsp.SubscriptionConfig.Target
 					}
+					for k, v := range t.Config.EventTags {
+						m[k] = v
+					}
 					if a.subscriptionMode(rsp.SubscriptionName) == "ONCE" {
 						a.Export(ctx, rsp.Response, m, t.Config.Outputs...)
 					} else {

--- a/docs/user_guide/targets.md
+++ b/docs/user_guide/targets.md
@@ -157,6 +157,10 @@ targets:
     retry:
     # list of tags, relevant when clustering is enabled.
     tags:
+    # a mapping of static tags to add to all events from this target.
+    # each key/value pair in this mapping will be added to metadata
+    # on all events
+    event-tags:
     # list of proto file names to decode protoBytes values
     proto-files:
     # list of directories to look for the proto files

--- a/types/target.go
+++ b/types/target.go
@@ -19,29 +19,30 @@ import (
 
 // TargetConfig //
 type TargetConfig struct {
-	Name          string        `mapstructure:"name,omitempty" json:"name,omitempty" yaml:"name,omitempty"`
-	Address       string        `mapstructure:"address,omitempty" json:"address,omitempty" yaml:"address,omitempty"`
-	Username      *string       `mapstructure:"username,omitempty" json:"username,omitempty" yaml:"username,omitempty"`
-	Password      *string       `mapstructure:"password,omitempty" json:"password,omitempty" yaml:"password,omitempty"`
-	Timeout       time.Duration `mapstructure:"timeout,omitempty" json:"timeout,omitempty" yaml:"timeout,omitempty"`
-	Insecure      *bool         `mapstructure:"insecure,omitempty" json:"insecure,omitempty" yaml:"insecure,omitempty"`
-	TLSCA         *string       `mapstructure:"tls-ca,omitempty" json:"tls-ca,omitempty" yaml:"tlsca,omitempty"`
-	TLSCert       *string       `mapstructure:"tls-cert,omitempty" json:"tls-cert,omitempty" yaml:"tls-cert,omitempty"`
-	TLSKey        *string       `mapstructure:"tls-key,omitempty" json:"tls-key,omitempty" yaml:"tls-key,omitempty"`
-	SkipVerify    *bool         `mapstructure:"skip-verify,omitempty" json:"skip-verify,omitempty" yaml:"skip-verify,omitempty"`
-	Subscriptions []string      `mapstructure:"subscriptions,omitempty" json:"subscriptions,omitempty" yaml:"subscriptions,omitempty"`
-	Outputs       []string      `mapstructure:"outputs,omitempty" json:"outputs,omitempty" yaml:"outputs,omitempty"`
-	BufferSize    uint          `mapstructure:"buffer-size,omitempty" json:"buffer-size,omitempty" yaml:"buffer-size,omitempty"`
-	RetryTimer    time.Duration `mapstructure:"retry,omitempty" json:"retry-timer,omitempty" yaml:"retry-timer,omitempty"`
-	TLSMinVersion string        `mapstructure:"tls-min-version,omitempty" json:"tls-min-version,omitempty" yaml:"tls-min-version,omitempty"`
-	TLSMaxVersion string        `mapstructure:"tls-max-version,omitempty" json:"tls-max-version,omitempty" yaml:"tls-max-version,omitempty"`
-	TLSVersion    string        `mapstructure:"tls-version,omitempty" json:"tls-version,omitempty" yaml:"tls-version,omitempty"`
-	LogTLSSecret  *bool         `mapstructure:"log-tls-secret,omitempty" json:"log-tls-secret,omitempty" yaml:"log-tls-secret,omitempty"`
-	ProtoFiles    []string      `mapstructure:"proto-files,omitempty" json:"proto-files,omitempty" yaml:"proto-files,omitempty"`
-	ProtoDirs     []string      `mapstructure:"proto-dirs,omitempty" json:"proto-dirs,omitempty" yaml:"proto-dirs,omitempty"`
-	Tags          []string      `mapstructure:"tags,omitempty" json:"tags,omitempty" yaml:"tags,omitempty"`
-	Gzip          *bool         `mapstructure:"gzip,omitempty" json:"gzip,omitempty" yaml:"gzip,omitempty"`
-	Token         *string       `mapstructure:"token,omitempty" json:"token,omitempty" yaml:"token,omitempty"`
+	Name          string            `mapstructure:"name,omitempty" json:"name,omitempty" yaml:"name,omitempty"`
+	Address       string            `mapstructure:"address,omitempty" json:"address,omitempty" yaml:"address,omitempty"`
+	Username      *string           `mapstructure:"username,omitempty" json:"username,omitempty" yaml:"username,omitempty"`
+	Password      *string           `mapstructure:"password,omitempty" json:"password,omitempty" yaml:"password,omitempty"`
+	Timeout       time.Duration     `mapstructure:"timeout,omitempty" json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	Insecure      *bool             `mapstructure:"insecure,omitempty" json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	TLSCA         *string           `mapstructure:"tls-ca,omitempty" json:"tls-ca,omitempty" yaml:"tlsca,omitempty"`
+	TLSCert       *string           `mapstructure:"tls-cert,omitempty" json:"tls-cert,omitempty" yaml:"tls-cert,omitempty"`
+	TLSKey        *string           `mapstructure:"tls-key,omitempty" json:"tls-key,omitempty" yaml:"tls-key,omitempty"`
+	SkipVerify    *bool             `mapstructure:"skip-verify,omitempty" json:"skip-verify,omitempty" yaml:"skip-verify,omitempty"`
+	Subscriptions []string          `mapstructure:"subscriptions,omitempty" json:"subscriptions,omitempty" yaml:"subscriptions,omitempty"`
+	Outputs       []string          `mapstructure:"outputs,omitempty" json:"outputs,omitempty" yaml:"outputs,omitempty"`
+	BufferSize    uint              `mapstructure:"buffer-size,omitempty" json:"buffer-size,omitempty" yaml:"buffer-size,omitempty"`
+	RetryTimer    time.Duration     `mapstructure:"retry,omitempty" json:"retry-timer,omitempty" yaml:"retry-timer,omitempty"`
+	TLSMinVersion string            `mapstructure:"tls-min-version,omitempty" json:"tls-min-version,omitempty" yaml:"tls-min-version,omitempty"`
+	TLSMaxVersion string            `mapstructure:"tls-max-version,omitempty" json:"tls-max-version,omitempty" yaml:"tls-max-version,omitempty"`
+	TLSVersion    string            `mapstructure:"tls-version,omitempty" json:"tls-version,omitempty" yaml:"tls-version,omitempty"`
+	LogTLSSecret  *bool             `mapstructure:"log-tls-secret,omitempty" json:"log-tls-secret,omitempty" yaml:"log-tls-secret,omitempty"`
+	ProtoFiles    []string          `mapstructure:"proto-files,omitempty" json:"proto-files,omitempty" yaml:"proto-files,omitempty"`
+	ProtoDirs     []string          `mapstructure:"proto-dirs,omitempty" json:"proto-dirs,omitempty" yaml:"proto-dirs,omitempty"`
+	Tags          []string          `mapstructure:"tags,omitempty" json:"tags,omitempty" yaml:"tags,omitempty"`
+	EventTags     map[string]string `mapstructure:"event-tags,omitempty" json:"event-tags,omitempty" yaml:"event-tags,omitempty"`
+	Gzip          *bool             `mapstructure:"gzip,omitempty" json:"gzip,omitempty" yaml:"gzip,omitempty"`
+	Token         *string           `mapstructure:"token,omitempty" json:"token,omitempty" yaml:"token,omitempty"`
 	//
 	TunnelTargetType string `mapstructure:"-" json:"tunnel-target-type,omitempty" yaml:"tunnel-target-type,omitempty"`
 }


### PR DESCRIPTION
These tags are a map whose key/value will be added to event metadata on every subscribe response for the target.

My use-case is to enrich all Prometheus metrics with a "site" label. For example, the config
```yaml
targets:
  switch1:
    event-tags:
      site: sitea
  switch2:
    event-tags:
      site: siteb
```
will result in events and ultimately Prometheus metrics (in my case) with an extra label site=sitea/siteb.

I would have preferred to call the field simply `tags`, but it's already in use by the clustering function and I didn't want to overload its meaning.