### PR TITLE
add event value -> tag copier

### DIFF
--- a/docs/user_guide/event_processors/event_value_tag.md
+++ b/docs/user_guide/event_processors/event_value_tag.md
@@ -1,0 +1,179 @@
+The `event-value-tag` processor applies specific values from event messages to tags of other messages, if event tag names match.
+
+Each [gNMI subscribe Response Update](https://github.com/openconfig/gnmi/blob/master/proto/gnmi/gnmi.proto#L95) in a [gNMI subscribe Response Notification](https://github.com/openconfig/gnmi/blob/master/proto/gnmi/gnmi.proto#L79) is transformed into an [Event Message](intro.md)  Additionally, if you are using an output cache, all [gNMI subscribe Response Update](https://github.com/openconfig/gnmi/blob/master/proto/gnmi/gnmi.proto#L95) messages are converted to Events on flush.
+
+The `event-value-tag` processor is used to extract Values as tags to apply to other Events that have the same K:V tag pairs from the original event message, without merging events with different timestamps.
+
+```yaml
+processors:
+  # processor name
+  intf-description:
+    # processor-type
+    event-value-tag:
+      # name of the value to match.  Usually a specific gNMI path
+      value-name: "/interfaces/interface/state/description"
+      # if set, use instead of the value name for tag
+      tag-name: "description"
+      # if true, remove value from original event when copying
+      consume: false
+      debug: false
+```
+
+=== "Event format before"
+    ```json
+    [
+        {
+            "name": "sub1",
+            "timestamp": 1,
+            "tags": {
+                "source": "leaf1:6030",
+                "subscription-name": "sub1",
+                "interface_name": "Ethernet1"
+            },
+            "values": {
+                "/interfaces/interface/status/counters/in-octets": 100
+            }
+        },
+        {
+            "name": "sub1",
+            "timestamp": 200,
+            "tags": {
+                "source": "leaf1:6030",
+                "subscription-name": "sub1",
+                "interface_name": "Ethernet1"
+            },
+            "values": {
+                "/interfaces/interface/status/counters/out-octets": 100
+            }
+        },
+        {
+            "name": "sub1",
+            "timestamp": 200,
+            "tags": {
+                "source": "leaf1:6030",
+                "subscription-name": "sub1",
+                "interface_name": "Ethernet1"
+            },
+            "values": {
+                "/interfaces/interface/status/description": "Uplink"
+            }
+        }
+    ]
+    ```
+=== "Event format after"
+    ```json
+    [
+        {
+            "name": "sub1",
+            "timestamp": 1,
+            "tags": {
+                "source": "leaf1:6030",
+                "subscription-name": "sub1",
+                "interface_name": "Ethernet1",
+                "description": "Uplink"
+            },
+            "values": {
+                "/interfaces/interface/status/counters/in-octets": 100
+            }
+        },
+        {
+            "name": "sub1",
+            "timestamp": 200,
+            "tags": {
+                "source": "leaf1:6030",
+                "subscription-name": "sub1",
+                "interface_name": "Ethernet1",
+                "description": "Uplink"
+            },
+            "values": {
+                "/interfaces/interface/status/counters/out-octets": 100
+            }
+        },
+        {
+            "name": "sub1",
+            "timestamp": 200,
+            "tags": {
+                "source": "leaf1:6030",
+                "subscription-name": "sub1",
+                "interface_name": "Ethernet1"
+            },
+            "values": {
+                "/interfaces/interface/status/description": "Uplink"
+            }
+        }
+    ]
+    ```
+
+```yaml
+  bgp-description:
+    event-value-tag:
+      value-name: "neighbor_description"
+      consume: true
+```
+=== "Event format before"
+    ```json
+    [
+        {
+            "name": "sub2",
+            "timestamp": 1615284691523204299,
+            "tags": {
+                "neighbor_peer-address": "2002::1:1:1:1",
+                "network-instance_name": "default",
+                "source": "leaf1:57400",
+                "subscription-name": "sub2"
+            },
+            "values": {
+                "bgp_neighbor_sent_messages_queue_depth": 0,
+                "bgp_neighbor_sent_messages_total_messages": "423",
+                "bgp_neighbor_sent_messages_total_non_updates": "415",
+                "bgp_neighbor_sent_messages_total_updates": "8"
+            }
+        },
+        {
+            "name": "sub2",
+            "timestamp": 1615284691523204299,
+            "tags": {
+                "neighbor_peer-address": "2002::1:1:1:1",
+                "network-instance_name": "default",
+                "source": "leaf1:57400",
+                "subscription-name": "sub2"
+            },
+            "values": {
+                "neighbor_description": "PeerRouter"
+            }
+        }
+    ]
+    ```
+=== "Event format after"
+    ```json
+    [
+        {
+            "name": "sub2",
+            "timestamp": 1615284691523204299,
+            "tags": {
+                "neighbor_peer-address": "2002::1:1:1:1",
+                "network-instance_name": "default",
+                "source": "leaf1:57400",
+                "subscription-name": "sub2"
+                "neighbor_description": "PeerRouter"
+            },
+            "values": {
+                "bgp_neighbor_sent_messages_queue_depth": 0,
+                "bgp_neighbor_sent_messages_total_messages": "423",
+                "bgp_neighbor_sent_messages_total_non_updates": "415",
+                "bgp_neighbor_sent_messages_total_updates": "8",
+            }
+        },
+        {
+            "name": "sub2",
+            "timestamp": 1615284691523204299,
+            "tags": {
+                "neighbor_peer-address": "2002::1:1:1:1",
+                "network-instance_name": "default",
+                "source": "leaf1:57400",
+                "subscription-name": "sub2"
+            },
+            "values": {}
+        }
+    ]
+    ```

--- a/formatters/all/all.go
+++ b/formatters/all/all.go
@@ -17,5 +17,6 @@ import (
 	_ "github.com/karimra/gnmic/formatters/event_strings"
 	_ "github.com/karimra/gnmic/formatters/event_to_tag"
 	_ "github.com/karimra/gnmic/formatters/event_trigger"
+	_ "github.com/karimra/gnmic/formatters/event_value_tag"
 	_ "github.com/karimra/gnmic/formatters/event_write"
 )

--- a/formatters/event_value_tag/event_value_tag.go
+++ b/formatters/event_value_tag/event_value_tag.go
@@ -1,0 +1,110 @@
+package event_value_tag
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/karimra/gnmic/formatters"
+	"github.com/karimra/gnmic/types"
+	"github.com/karimra/gnmic/utils"
+)
+
+const (
+	processorType = "event-value-tag"
+	loggingPrefix = "[" + processorType + "] "
+)
+
+type ValueTag struct {
+	TagName   string `mapstructure:"tag-name,omitempty" json:"tag-name,omitempty"`
+	ValueName string `mapstructure:"value-name,omitempty" json:"value-name,omitempty"`
+	Consume   bool   `mapstructure:"consume,omitempty" json:"consume,omitempty"`
+	Debug     bool   `mapstructure:"debug,omitempty" json:"debug,omitempty"`
+	logger    *log.Logger
+}
+
+func init() {
+	formatters.Register(processorType, func() formatters.EventProcessor {
+		return &ValueTag{logger: log.New(io.Discard, "", 0)}
+	})
+}
+
+func (vt *ValueTag) Init(cfg interface{}, opts ...formatters.Option) error {
+	err := formatters.DecodeConfig(cfg, vt)
+	if err != nil {
+		return err
+	}
+	for _, opt := range opts {
+		opt(vt)
+	}
+
+	if vt.logger.Writer() != io.Discard {
+		b, err := json.Marshal(vt)
+		if err != nil {
+			vt.logger.Printf("initialized processor '%s': %+v", processorType, vt)
+			return nil
+		}
+		vt.logger.Printf("initialized processor '%s': %s", processorType, string(b))
+	}
+	return nil
+}
+
+type foo struct {
+	tags  map[string]string
+	value interface{}
+}
+
+func (vt *ValueTag) Apply(evs ...*formatters.EventMsg) []*formatters.EventMsg {
+	if vt.TagName == "" {
+		vt.TagName = vt.ValueName
+	}
+	// Look for events with ValueName
+	toApply := make([]foo, 0)
+	for _, ev := range evs {
+		for k, v := range ev.Values {
+			if vt.ValueName == k {
+				toApply = append(toApply, foo{ev.Tags, v})
+				if vt.Consume {
+					delete(ev.Values, k)
+				}
+			}
+		}
+	}
+	for _, bar := range toApply {
+		for _, ev := range evs {
+			if checkKeys(bar.tags, ev.Tags) {
+				if _, ok := ev.Values[vt.ValueName]; !ok {
+					ev.Tags[vt.TagName] = fmt.Sprint(bar.value)
+				}
+			}
+		}
+	}
+	return evs
+}
+
+func (vt *ValueTag) WithLogger(l *log.Logger) {
+	if vt.Debug && l != nil {
+		vt.logger = log.New(l.Writer(), loggingPrefix, l.Flags())
+	} else if vt.Debug {
+		vt.logger = log.New(os.Stderr, loggingPrefix, utils.DefaultLoggingFlags)
+	}
+}
+
+func (vt *ValueTag) WithTargets(tcs map[string]*types.TargetConfig) {}
+
+func (vt *ValueTag) WithActions(act map[string]map[string]interface{}) {}
+
+func checkKeys(a map[string]string, b map[string]string) bool {
+	for k, v := range a {
+		if vv, ok := b[k]; ok {
+			if v != vv {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}

--- a/formatters/event_value_tag/event_value_tag_test.go
+++ b/formatters/event_value_tag/event_value_tag_test.go
@@ -1,0 +1,242 @@
+package event_value_tag
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/karimra/gnmic/formatters"
+)
+
+type item struct {
+	input  []*formatters.EventMsg
+	output []*formatters.EventMsg
+}
+
+var testset = map[string]struct {
+	processorType string
+	processor     map[string]interface{}
+	tests         []item
+}{
+	"no-options": {
+		processorType: processorType,
+		processor: map[string]interface{}{
+			"value-name": "foo",
+		},
+		tests: []item{
+			{
+				input:  nil,
+				output: nil,
+			},
+			{
+				input:  make([]*formatters.EventMsg, 0),
+				output: make([]*formatters.EventMsg, 0),
+			},
+			{
+				input: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value"},
+						Values:    map[string]interface{}{"foo": "value"},
+					},
+				},
+				output: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value", "foo": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value"},
+						Values:    map[string]interface{}{"foo": "value"},
+					},
+				},
+			},
+			{
+				input: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value"},
+						Values:    map[string]interface{}{"bar": "value"},
+					},
+				},
+				output: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value"},
+						Values:    map[string]interface{}{"bar": "value"},
+					},
+				},
+			},
+		},
+	},
+	"rename-tag": {
+		processorType: processorType,
+		processor: map[string]interface{}{
+			"value-name": "foo",
+			"tag-name":   "bar",
+		},
+		tests: []item{
+			{
+				input:  nil,
+				output: nil,
+			},
+			{
+				input:  make([]*formatters.EventMsg, 0),
+				output: make([]*formatters.EventMsg, 0),
+			},
+			{
+				input: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value"},
+						Values:    map[string]interface{}{"foo": "value"},
+					},
+				},
+				output: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value", "bar": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value"},
+						Values:    map[string]interface{}{"foo": "value"},
+					},
+				},
+			},
+			{
+				input: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value"},
+						Values:    map[string]interface{}{"bar": "value"},
+					},
+				},
+				output: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value"},
+						Values:    map[string]interface{}{"bar": "value"},
+					},
+				},
+			},
+		},
+	},
+	"consume-value": {
+		processorType: processorType,
+		processor: map[string]interface{}{
+			"value-name": "foo",
+			"consume":    true,
+		},
+		tests: []item{
+			{
+				input:  nil,
+				output: nil,
+			},
+			{
+				input:  make([]*formatters.EventMsg, 0),
+				output: make([]*formatters.EventMsg, 0),
+			},
+			{
+				input: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value"},
+						Values:    map[string]interface{}{"foo": "value"},
+					},
+				},
+				output: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value", "foo": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value", "foo": "value"},
+						Values:    make(map[string]interface{}, 0),
+					},
+				},
+			},
+			{
+				input: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value"},
+						Values:    map[string]interface{}{"bar": "value"},
+					},
+				},
+				output: []*formatters.EventMsg{
+					{
+						Timestamp: 1,
+						Tags:      map[string]string{"tag": "value"},
+					},
+					{
+						Timestamp: 2,
+						Tags:      map[string]string{"tag": "value"},
+						Values:    map[string]interface{}{"bar": "value"},
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestEventValueTag(t *testing.T) {
+	for name, ts := range testset {
+		if pi, ok := formatters.EventProcessors[ts.processorType]; ok {
+			t.Log("found processor")
+			p := pi()
+			err := p.Init(ts.processor)
+			if err != nil {
+				t.Errorf("failed to initialize processors: %v", err)
+				return
+			}
+			t.Logf("processor: %+v", p)
+			for i, item := range ts.tests {
+				t.Run(name, func(t *testing.T) {
+					t.Logf("running test item %d", i)
+					outs := p.Apply(item.input...)
+					for j := range outs {
+						if !reflect.DeepEqual(outs[j], item.output[j]) {
+							t.Errorf("failed at %s item %d, index %d, expected %+v, got: %+v", name, i, j, item.output[j], outs[j])
+						}
+					}
+				})
+			}
+		} else {
+			t.Errorf("event processor %s not found", ts.processorType)
+		}
+	}
+}

--- a/formatters/processors.go
+++ b/formatters/processors.go
@@ -29,6 +29,7 @@ var EventProcessorTypes = []string{
 	"event-write",
 	"event-group-by",
 	"event-data-convert",
+	"event-value-tag",
 }
 
 type Initializer func() EventProcessor


### PR DESCRIPTION
Add a new event processor that can copy a value from one event to
multiple other events.  If all tags present on the donor event are
identical on another event, apply the value as a new tag on the other
event.

The primary use case for this is when dealing with an output cache and
an Arista software device.  Arista splits all of its leaves into
separate Update messages, each with a different timestamp.  To avoid
losing precision of the individual counters, a merge is not desired, as
it would overwrite some timestamps, creating new TSDB datapoints where
they may not have existed before, and possibly throwing off delta
calculations.