### PR TITLE
refactor prometheus cache to general output cache

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,148 @@
+package cache
+
+import (
+	"io"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/karimra/gnmic/formatters"
+	"github.com/karimra/gnmic/outputs"
+	"github.com/karimra/gnmic/utils"
+	gnmiCache "github.com/openconfig/gnmi/cache"
+	"github.com/openconfig/gnmi/ctree"
+	"github.com/openconfig/gnmi/proto/gnmi"
+)
+
+const (
+	loggingPrefix  = "[cache] "
+	defaultTimeout = 10 * time.Second
+)
+
+type GnmiCacheConfig struct {
+	Expiration time.Duration `mapstructure:"expiration,omitempty"`
+	Timeout    time.Duration `mapstructure:"timeout,omitempty"`
+	Debug      bool          `mapstructure:"debug,omitempty"`
+}
+
+func (gcc *GnmiCacheConfig) SetDefaults() {
+	if gcc.Timeout == 0 {
+		gcc.Timeout = defaultTimeout
+	}
+}
+
+type GnmiOutputCache struct {
+	sync.Mutex
+	caches     map[string]*gnmiCache.Cache
+	logger     *log.Logger
+	expiration time.Duration
+	timeout    time.Duration
+	debug      bool
+}
+
+func (gc *GnmiOutputCache) LoadConfig(gcc *GnmiCacheConfig) {
+	gc.expiration = gcc.Expiration
+	gc.timeout = gcc.Timeout
+	gc.logger = log.New(io.Discard, loggingPrefix, utils.DefaultLoggingFlags)
+	gc.caches = make(map[string]*gnmiCache.Cache)
+	gc.debug = gcc.Debug
+
+}
+
+func (gc *GnmiOutputCache) Init(opts ...Option) {
+	for _, opt := range opts {
+		opt(gc)
+	}
+}
+
+func (gc *GnmiOutputCache) SetLogger(logger *log.Logger) {
+	if logger != nil && gc.logger != nil {
+		gc.logger.SetOutput(logger.Writer())
+		gc.logger.SetFlags(logger.Flags())
+	}
+}
+
+func (gc *GnmiOutputCache) Write(measName string, rsp *gnmi.SubscribeResponse) {
+	var err error
+	switch rsp := rsp.GetResponse().(type) {
+	case *gnmi.SubscribeResponse_Update:
+		target := rsp.Update.GetPrefix().GetTarget()
+		if target == "" {
+			gc.logger.Printf("response missing target")
+			return
+		}
+		gc.Lock()
+		defer gc.Unlock()
+		if _, ok := gc.caches[measName]; !ok {
+			gc.caches[measName] = gnmiCache.New(nil)
+			gc.caches[measName].Add(target)
+		} else if !gc.caches[measName].HasTarget(target) {
+			gc.caches[measName].Add(target)
+			gc.logger.Printf("target %q added to the local cache", target)
+		}
+		err = gc.caches[measName].GnmiUpdate(rsp.Update)
+		if err != nil && gc.debug {
+			gc.logger.Printf("failed to update gNMI cache: %v", err)
+		}
+		return
+	}
+}
+
+func (gc *GnmiOutputCache) Read() []*formatters.EventMsg {
+	var err error
+	gc.Lock()
+	defer gc.Unlock()
+	evChan := make(chan []*formatters.EventMsg)
+	events := make([]*formatters.EventMsg, 0)
+	doneCh := make(chan struct{})
+	// this go routine will collect all the events
+	// from the cache queries
+	go func() {
+		for evs := range evChan {
+			events = append(events, evs...)
+		}
+		close(doneCh)
+	}()
+
+	now := time.Now()
+	wg := new(sync.WaitGroup)
+	wg.Add(len(gc.caches))
+	for name, c := range gc.caches {
+		go func(c *gnmiCache.Cache, name string) {
+			defer wg.Done()
+			err = c.Query("*", []string{},
+				func(_ []string, l *ctree.Leaf, v interface{}) error {
+					if err != nil {
+						return err
+					}
+					switch notif := v.(type) {
+					case *gnmi.Notification:
+						if gc.expiration > 0 &&
+							time.Unix(0, notif.Timestamp).Before(now.Add(time.Duration(-gc.expiration))) {
+							return nil
+						}
+						// build events without processors
+						events, err := formatters.ResponseToEventMsgs(name, &gnmi.SubscribeResponse{
+							Response: &gnmi.SubscribeResponse_Update{Update: notif},
+						},
+							outputs.Meta{"subscription-name": name})
+						if err != nil {
+							gc.logger.Printf("failed to convert message to event: %v", err)
+							return nil
+						}
+						evChan <- events
+					}
+					return nil
+				})
+			if err != nil {
+				gc.logger.Printf("failed prometheus cache query:%v", err)
+				return
+			}
+		}(c, name)
+	}
+	wg.Wait()
+	close(evChan)
+	// wait for events to be appended to the array
+	<-doneCh
+	return events
+}

--- a/cache/options.go
+++ b/cache/options.go
@@ -1,0 +1,11 @@
+package cache
+
+import "log"
+
+type Option func(*GnmiOutputCache)
+
+func WithLogger(logger *log.Logger) Option {
+	return func(gc *GnmiOutputCache) {
+		gc.SetLogger(logger)
+	}
+}

--- a/outputs/influxdb_output/influxdb_cache.go
+++ b/outputs/influxdb_output/influxdb_cache.go
@@ -1,0 +1,50 @@
+package influxdb_output
+
+import (
+	"time"
+
+	"github.com/karimra/gnmic/cache"
+)
+
+func (i *InfluxDBOutput) initCache() {
+	i.Cfg.GnmiCacheConfig.SetDefaults()
+	i.gnmiCache = &cache.GnmiOutputCache{}
+	i.gnmiCache.LoadConfig(i.Cfg.GnmiCacheConfig)
+	i.gnmiCache.Init(cache.WithLogger(i.logger))
+	i.cacheTicker = time.NewTicker(i.Cfg.CacheFlushTimer)
+	i.done = make(chan struct{})
+	go i.runCache()
+}
+
+func (i *InfluxDBOutput) stopCache() {
+	i.cacheTicker.Stop()
+	close(i.done)
+}
+
+func (i *InfluxDBOutput) runCache() {
+	for {
+		select {
+		case <-i.done:
+			return
+		case <-i.cacheTicker.C:
+			if i.Cfg.Debug {
+				i.logger.Printf("cache timer tick")
+			}
+			i.readCache()
+		}
+	}
+}
+
+func (i *InfluxDBOutput) readCache() {
+	events := i.gnmiCache.Read()
+	for _, proc := range i.evps {
+		events = proc.Apply(events...)
+	}
+	for _, ev := range events {
+		select {
+		case <-i.reset:
+			return
+		case i.eventChan <- ev:
+		}
+	}
+}

--- a/outputs/prometheus_output/prometheus_cache.go
+++ b/outputs/prometheus_output/prometheus_cache.go
@@ -2,128 +2,37 @@ package prometheus_output
 
 import (
 	"context"
-	"sync"
 	"time"
 
-	"github.com/karimra/gnmic/formatters"
-	"github.com/karimra/gnmic/outputs"
-	"github.com/openconfig/gnmi/cache"
-	"github.com/openconfig/gnmi/ctree"
-	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/karimra/gnmic/cache"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func (p *prometheusOutput) writeToCache(measName string, rsp *gnmi.SubscribeResponse) {
-	var err error
-	switch rsp := rsp.GetResponse().(type) {
-	case *gnmi.SubscribeResponse_Update:
-		target := rsp.Update.GetPrefix().GetTarget()
-		if target == "" {
-			p.logger.Printf("response missing target")
-			return
-		}
-		p.Lock()
-		defer p.Unlock()
-		if _, ok := p.caches[measName]; !ok {
-			p.caches[measName] = cache.New(nil)
-			p.caches[measName].Add(target)
-		} else if !p.caches[measName].HasTarget(target) {
-			p.caches[measName].Add(target)
-			p.logger.Printf("target %q added to the local cache", target)
-		}
-		if p.Cfg.Debug {
-			p.logger.Printf("updating target %q local cache", target)
-		}
-		err = p.caches[measName].GnmiUpdate(rsp.Update)
-		if err != nil {
-			p.logger.Printf("failed to update gNMI cache: %v", err)
-		}
-		return
-	}
+func (p *prometheusOutput) initCache() {
+	cfg := &cache.GnmiCacheConfig{}
+	cfg.SetDefaults()
+	cfg.Expiration = p.Cfg.Expiration
+	cfg.Timeout = p.Cfg.Timeout
+	cfg.Debug = p.Cfg.Debug
+	p.gnmiCache = &cache.GnmiOutputCache{}
+	p.gnmiCache.LoadConfig(cfg)
+	p.gnmiCache.Init(cache.WithLogger(p.logger))
 }
-
-// collectFromCache does the following:
-// - runs queries over all the stored caches,
-// - retrives the gNMI notifications that are not older that the expiration duration.
-// - generates a lit of events from the gNMI notifications list.
-// - applies the configured processors on the events list.
-// - generates prometheus metrics from the events and sends them to chan<- prometheus.Metric
 func (p *prometheusOutput) collectFromCache(ch chan<- prometheus.Metric) {
-	var err error
-	evChan := make(chan []*formatters.EventMsg)
-	events := make([]*formatters.EventMsg, 0)
-	doneCh := make(chan struct{})
-	// this go routine will collect all the events
-	// from the cache queries
-	go func() {
-		for evs := range evChan {
-			events = append(events, evs...)
-		}
-		close(doneCh)
-	}()
-
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
-
-	now := time.Now()
-	wg := new(sync.WaitGroup)
-	wg.Add(len(p.caches))
-	for name, c := range p.caches {
-		go func(c *cache.Cache, name string) {
-			defer wg.Done()
-			err = c.Query("*", []string{},
-				func(_ []string, l *ctree.Leaf, v interface{}) error {
-					if err != nil {
-						return err
-					}
-					switch notif := v.(type) {
-					case *gnmi.Notification:
-						if p.Cfg.Expiration > 0 &&
-							time.Unix(0, notif.Timestamp).Before(now.Add(time.Duration(-p.Cfg.Expiration))) {
-							return nil
-						}
-						// build events without processors
-						events, err := formatters.ResponseToEventMsgs(name, &gnmi.SubscribeResponse{
-							Response: &gnmi.SubscribeResponse_Update{Update: notif},
-						},
-							outputs.Meta{"subscription-name": name})
-						if err != nil {
-							p.logger.Printf("failed to convert message to event: %v", err)
-							return nil
-						}
-						evChan <- events
-					}
-					return nil
-				})
-			if err != nil {
-				p.logger.Printf("failed prometheus cache query:%v", err)
-				return
-			}
-		}(c, name)
+	events := p.gnmiCache.Read()
+	for _, proc := range p.evps {
+		events = proc.Apply(events...)
 	}
-	wg.Wait()
-	close(evChan)
-	// wait for events to be appended to the array
-	<-doneCh
-	select {
-	// check if the collection timeout context is done
-	case <-ctx.Done():
-		p.logger.Printf("collection context terminated: %v", ctx.Err())
-		return
-	default:
-		// apply processors
-		for _, proc := range p.evps {
-			events = proc.Apply(events...)
-		}
-		// build prometheus metrics and send
-		for _, ev := range events {
-			for _, pm := range p.metricsFromEvent(ev, now) {
-				select {
-				case <-ctx.Done():
-					p.logger.Printf("collection context terminated: %v", ctx.Err())
-					return
-				case ch <- pm:
-				}
+	now := time.Now()
+	for _, ev := range events {
+		for _, pm := range p.metricsFromEvent(ev, now) {
+			select {
+			case <-ctx.Done():
+				p.logger.Printf("collection context terminated: %v", ctx.Err())
+				return
+			case ch <- pm:
 			}
 		}
 	}


### PR DESCRIPTION
Arista devices do not bundle Update messages into a single Notification, preferring to send all updates with their own timestamp (see https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#3521-bundling-of-telemetry-update for details).  This can make it difficult to run event processors that expect multiple events in a single Notification.  Use of a per-subscription cache solves this -- the entire cache can be converted to events on a regular schedule and flushed by the upstream output per its needs (on scrape for prometheus, on a timer for Influx, etc)

As long as the flush interval is lower than whatever sample interval is being used in a subscription, no data would be lost.  Repeated sending of the same data (flushing more often than sample interval) doesn't result in extra storage, only extra network traffic, as most TSDB will discard identical points in the same metric
