### PR TITLE
SOCKS5 proxy support for targets

### DIFF
--- a/docs/user_guide/targets.md
+++ b/docs/user_guide/targets.md
@@ -167,6 +167,8 @@ targets:
     proto-dirs:
     # enable grpc gzip compression
     gzip: 
+    # address of the target's SOCKS5 proxy server
+    socks-address:
 ```
 
 ### Example

--- a/docs/user_guide/targets.md
+++ b/docs/user_guide/targets.md
@@ -167,8 +167,9 @@ targets:
     proto-dirs:
     # enable grpc gzip compression
     gzip: 
-    # address of the target's SOCKS5 proxy server
-    socks-address:
+    # proxy type and address, only SOCKS5 is supported currently
+    # example: socks5://<address>:<port>
+    proxy:
 ```
 
 ### Example

--- a/target/target.go
+++ b/target/target.go
@@ -3,6 +3,7 @@ package target
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/karimra/gnmic/types"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
+	"golang.org/x/net/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -81,6 +83,22 @@ func (t *Target) CreateGNMIClient(ctx context.Context, opts ...grpc.DialOption) 
 		go func(addr string) {
 			timeoutCtx, cancel := context.WithTimeout(ctx, t.Config.Timeout)
 			defer cancel()
+			if t.Config.SocksAddress != "" {
+				dialer, err := proxy.SOCKS5("tcp", t.Config.SocksAddress, nil,
+					&net.Dialer{
+						Timeout:   t.Config.Timeout,
+						KeepAlive: t.Config.Timeout,
+					},
+				)
+				if err != nil {
+					errC <- fmt.Errorf("%s: %v", addr, err)
+					return
+				}
+				opts = append(opts, grpc.WithContextDialer(
+					func(ctx context.Context, addr string) (net.Conn, error) {
+						return dialer.Dial("tcp", addr)
+					}))
+			}
 			conn, err := grpc.DialContext(timeoutCtx, addr, opts...)
 			if err != nil {
 				errC <- fmt.Errorf("%s: %v", addr, err)

--- a/types/target.go
+++ b/types/target.go
@@ -43,6 +43,7 @@ type TargetConfig struct {
 	EventTags     map[string]string `mapstructure:"event-tags,omitempty" json:"event-tags,omitempty" yaml:"event-tags,omitempty"`
 	Gzip          *bool             `mapstructure:"gzip,omitempty" json:"gzip,omitempty" yaml:"gzip,omitempty"`
 	Token         *string           `mapstructure:"token,omitempty" json:"token,omitempty" yaml:"token,omitempty"`
+	SocksAddress  string            `mapstructure:"socks-address,omitempty" json:"socks-address,omitempty" yaml:"socks-address,omitempty"`
 	//
 	TunnelTargetType string `mapstructure:"-" json:"tunnel-target-type,omitempty" yaml:"tunnel-target-type,omitempty"`
 }

--- a/types/target.go
+++ b/types/target.go
@@ -43,7 +43,7 @@ type TargetConfig struct {
 	EventTags     map[string]string `mapstructure:"event-tags,omitempty" json:"event-tags,omitempty" yaml:"event-tags,omitempty"`
 	Gzip          *bool             `mapstructure:"gzip,omitempty" json:"gzip,omitempty" yaml:"gzip,omitempty"`
 	Token         *string           `mapstructure:"token,omitempty" json:"token,omitempty" yaml:"token,omitempty"`
-	SocksAddress  string            `mapstructure:"socks-address,omitempty" json:"socks-address,omitempty" yaml:"socks-address,omitempty"`
+	Proxy         string            `mapstructure:"proxy,omitempty" json:"proxy,omitempty" yaml:"proxy,omitempty"`
 	//
 	TunnelTargetType string `mapstructure:"-" json:"tunnel-target-type,omitempty" yaml:"tunnel-target-type,omitempty"`
 }


### PR DESCRIPTION
Hi @karimra,

The use of proxy servers using the SOCKS protocol is becoming increasingly popular. This PR enables reaching targets behind a SOCKS5 proxy server without the need for an additional SOCKS client software and a dedicated gNMIc instance per proxy.

Please do not hesitate to contact me if you have questions, concerns or additional changes you need.