### PR TITLE
install-script-darwin-arm64-update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,10 @@ runAsRoot() {
 # verifySupported checks that the os/arch combination is supported
 verifySupported() {
     local supported="darwin-x86_64\ndarwin-aarch64\nlinux-i386\nlinux-x86_64\nlinux-armv7\nlinux-aarch64"
+    # change ARCH to "aarch64" if OS="darwin" and ARCH="arm64"
+    if [ ${OS} == "darwin" ] && [ ${ARCH} == "arm64" ]; then
+        ARCH="aarch64"
+    fi
     if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
         echo "No prebuilt binary for ${OS}-${ARCH}."
         echo "To build from source, go to ${REPO_URL}"
@@ -149,10 +153,6 @@ downloadFile() {
             exit 1
         fi
         EXT=$PKG_FORMAT
-    fi
-    # change ARCH to "aarch64" if OS="darwin" and ARCH="arm64"
-    if [ ${OS} == "darwin" ] && [ ${ARCH} == "arm64" ]; then
-        ARCH="aarch64"
     fi
     ARCHIVE="${PROJECT_NAME}_${TAG_WO_VER}_${OS}_${ARCH}.${EXT}"
     DOWNLOAD_URL="${REPO_URL}/releases/download/${TAG}/${ARCHIVE}"


### PR DESCRIPTION
Moved "change ARCH" from downloadFile() to verifySupported(), because ARCH verification occurs earlier

```
No prebuilt binary for darwin-arm64.
To build from source, go to https://github.com/karimra/gnmic
Failed to install gnmic```