### PR TITLE
Kubernetes clustering improvements

### DIFF
--- a/lockers/k8s_locker/k8s_locker.go
+++ b/lockers/k8s_locker/k8s_locker.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	defaultLeaseDuration = 10 * time.Second
+	defaultRetryTimer    = 2 * time.Second
 	loggingPrefix        = "[k8s_locker] "
 	defaultNamespace     = "default"
 	origKeyName          = "original-key"
@@ -58,6 +59,7 @@ type config struct {
 	Namespace     string        `mapstructure:"namespace,omitempty" json:"namespace,omitempty"`
 	LeaseDuration time.Duration `mapstructure:"lease-duration,omitempty" json:"lease-duration,omitempty"`
 	RenewPeriod   time.Duration `mapstructure:"renew-period,omitempty" json:"renew-period,omitempty"`
+	RetryTimer    time.Duration `mapstructure:"retry-timer,omitempty" json:"retry-timer,omitempty"`
 	Debug         bool          `mapstructure:"debug,omitempty" json:"debug,omitempty"`
 }
 
@@ -301,6 +303,9 @@ func (k *k8sLocker) setDefaults() error {
 	}
 	if k.Cfg.RenewPeriod <= 0 || k.Cfg.RenewPeriod >= k.Cfg.LeaseDuration {
 		k.Cfg.RenewPeriod = k.Cfg.LeaseDuration / 2
+	}
+	if k.Cfg.RetryTimer <= 0 {
+		k.Cfg.RetryTimer = defaultRetryTimer
 	}
 	return nil
 }

--- a/lockers/k8s_locker/k8s_locker.go
+++ b/lockers/k8s_locker/k8s_locker.go
@@ -159,15 +159,21 @@ func (k *k8sLocker) Lock(ctx context.Context, key string, val []byte) (bool, err
 			}
 			// obtained, compare
 			if ol != nil && ol.Spec.HolderIdentity != nil && *ol.Spec.HolderIdentity != "" {
-				k.logger.Printf("%q held by other instance: %v", ol.Name, *ol.Spec.HolderIdentity != k.identity)
-				k.logger.Printf("%q lease has renewTime: %v", ol.Name, ol.Spec.RenewTime != nil)
+				if k.Cfg.Debug {
+					k.logger.Printf("%q held by other instance: %v", ol.Name, *ol.Spec.HolderIdentity != k.identity)
+					k.logger.Printf("%q lease has renewTime: %v", ol.Name, ol.Spec.RenewTime != nil)
+				}
 				if *ol.Spec.HolderIdentity != k.identity && ol.Spec.RenewTime != nil {
 					expectedRenewTime := ol.Spec.RenewTime.Add(time.Duration(*ol.Spec.LeaseDurationSeconds) * time.Second)
-					k.logger.Printf("%q existing lease renew time %v", ol.Name, ol.Spec.RenewTime)
-					k.logger.Printf("%q expected lease renew time %v", ol.Name, expectedRenewTime)
-					k.logger.Printf("%q renew time passed: %v", ol.Name, expectedRenewTime.Before(now.Time))
+					if k.Cfg.Debug {
+						k.logger.Printf("%q existing lease renew time %v", ol.Name, ol.Spec.RenewTime)
+						k.logger.Printf("%q expected lease renew time %v", ol.Name, expectedRenewTime)
+						k.logger.Printf("%q renew time passed: %v", ol.Name, expectedRenewTime.Before(now.Time))
+					}
 					if !expectedRenewTime.Before(now.Time) {
-						k.logger.Printf("%q is currently held by %s", ol.Name, *ol.Spec.HolderIdentity)
+						if k.Cfg.Debug {
+							k.logger.Printf("%q is currently held by %s", ol.Name, *ol.Spec.HolderIdentity)
+						}
 						time.Sleep(k.Cfg.RenewPeriod)
 						continue
 					}

--- a/lockers/k8s_locker/k8s_registration.go
+++ b/lockers/k8s_locker/k8s_registration.go
@@ -49,9 +49,9 @@ func (k *k8sLocker) WatchServices(ctx context.Context, serviceName string, tags 
 func (k *k8sLocker) watch(ctx context.Context, serviceName string, tags []string, sChan chan<- []*lockers.Service, watchTimeout time.Duration, resourceVersion string) (string, error) {
 	timeoutSeconds := int64(watchTimeout.Seconds())
 	listopts := metav1.ListOptions{
-		FieldSelector:        fields.OneTermEqualSelector(metav1.ObjectNameField, serviceName).String(),
-		ResourceVersion:      resourceVersion,
-		TimeoutSeconds:       &timeoutSeconds,
+		FieldSelector:   fields.OneTermEqualSelector(metav1.ObjectNameField, serviceName).String(),
+		ResourceVersion: resourceVersion,
+		TimeoutSeconds:  &timeoutSeconds,
 	}
 	if k.Cfg.Debug {
 		if resourceVersion == "" {

--- a/lockers/k8s_locker/k8s_registration.go
+++ b/lockers/k8s_locker/k8s_registration.go
@@ -7,8 +7,11 @@ import (
 	"time"
 
 	"github.com/karimra/gnmic/lockers"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 const defaultWatchTimeout = 10 * time.Second
@@ -21,43 +24,96 @@ func (k *k8sLocker) Deregister(s string) error {
 	return nil
 }
 
-func (k *k8sLocker) WatchServices(ctx context.Context, serviceName string, tags []string, sChan chan<- []*lockers.Service, _ time.Duration) error {
-	// if watchTimeout <= 0 {
-	watchTimeout := defaultWatchTimeout
-	// }
+func (k *k8sLocker) WatchServices(ctx context.Context, serviceName string, tags []string, sChan chan<- []*lockers.Service, watchTimeout time.Duration) error {
+	if watchTimeout <= 0 {
+		watchTimeout = defaultWatchTimeout
+	}
+	resourceVersion := ""
+	var err error
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			services, err := k.GetServices(ctx, serviceName, tags)
+			resourceVersion, err = k.watch(ctx, serviceName, tags, sChan, watchTimeout, resourceVersion)
 			if err != nil {
-				return err
+				k.logger.Printf("watch ended with error: %s", err)
+				time.Sleep(k.Cfg.RetryTimer)
+			} else if k.Cfg.Debug {
+				k.logger.Print("watch timed out")
 			}
-			sChan <- services
-			time.Sleep(watchTimeout)
 		}
 	}
 }
 
-func (k *k8sLocker) GetServices(ctx context.Context, serviceName string, tags []string) ([]*lockers.Service, error) {
-	ep, err := k.clientset.CoreV1().Endpoints(k.Cfg.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
+func (k *k8sLocker) watch(ctx context.Context, serviceName string, tags []string, sChan chan<- []*lockers.Service, watchTimeout time.Duration, resourceVersion string) (string, error) {
+	timeoutSeconds := int64(watchTimeout.Seconds())
+	listopts := metav1.ListOptions{
+		FieldSelector:        fields.OneTermEqualSelector(metav1.ObjectNameField, serviceName).String(),
+		ResourceVersion:      resourceVersion,
+		TimeoutSeconds:       &timeoutSeconds,
 	}
+	if k.Cfg.Debug {
+		if resourceVersion == "" {
+			k.logger.Print("starting watch beginning with unspecified resource version")
+		} else {
+			k.logger.Printf("starting watch beginning with resource version %s", resourceVersion)
+		}
+	}
+	watched, err := k.clientset.CoreV1().Endpoints(k.Cfg.Namespace).Watch(ctx, listopts)
+	if err != nil {
+		return "", err
+	}
+	defer watched.Stop()
 
+	watchChan := watched.ResultChan()
+
+	for {
+		event := <- watchChan
+		switch event.Type {
+		case watch.Modified, watch.Added:
+			endpoints, ok := event.Object.(*corev1.Endpoints)
+			if !ok {
+				// this ought not to happen, but we should probably
+				// start from scratch next time in case it does
+				return "", fmt.Errorf("error converting watch result to an endpoint")
+			}
+			resourceVersion = endpoints.ResourceVersion
+			if k.Cfg.Debug {
+				k.logger.Printf("received watch event %s for resource version %s", event.Type, resourceVersion)
+			}
+			svcs, err := parseEndpoint(endpoints)
+			if err != nil {
+				return "", err
+			}
+			sChan <- svcs
+		case "":
+			// reached the timeout. return the version we last saw so
+			// we can resume watching
+			return resourceVersion, nil
+		default:
+			// something else happened, including maybe the object we
+			// were watching being deleted. we'll need to start the
+			// next watch from scratch, so don't return the resource
+			// version
+			return "", fmt.Errorf("unexpected watch event: %s", event.Type)
+		}
+	}
+}
+
+func parseEndpoint(endpoint *corev1.Endpoints) ([]*lockers.Service, error) {
 	// the service should only have a single port number assigned, so
 	// all subsets should have the port number we're looking for
-	if len(ep.Subsets) <= 0 {
-		return nil, fmt.Errorf("no subsets found in endpoint for service %s", serviceName)
+	if len(endpoint.Subsets) <= 0 {
+		return nil, fmt.Errorf("no subsets found in endpoint for service %s", endpoint.Name)
 	}
-	if len(ep.Subsets[0].Ports) <= 0 {
-		return nil, fmt.Errorf("no ports found for service %s", serviceName)
+	if len(endpoint.Subsets[0].Ports) <= 0 {
+		return nil, fmt.Errorf("no ports found for service %s", endpoint.Name)
 	}
-	port := ep.Subsets[0].Ports[0].Port
+	port := endpoint.Subsets[0].Ports[0].Port
 
-	services := make([]*lockers.Service, 0, len(ep.Subsets[0].Addresses))
-	for _, subset := range ep.Subsets {
+	services := make([]*lockers.Service, 0, len(endpoint.Subsets[0].Addresses))
+	for _, subset := range endpoint.Subsets {
 		for _, addr := range subset.Addresses {
 			targetName := addr.IP
 			if addr.TargetRef != nil {
@@ -75,6 +131,15 @@ func (k *k8sLocker) GetServices(ctx context.Context, serviceName string, tags []
 	}
 
 	return services, nil
+}
+
+func (k *k8sLocker) GetServices(ctx context.Context, serviceName string, tags []string) ([]*lockers.Service, error) {
+	ep, err := k.clientset.CoreV1().Endpoints(k.Cfg.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return parseEndpoint(ep)
 }
 
 func (k *k8sLocker) IsLocked(ctx context.Context, key string) (bool, error) {


### PR DESCRIPTION
I was excited to see the Kubernetes clustering feature from https://github.com/karimra/gnmic/issues/560 in 0.25.0. When testing, I noticed the frequent service update log messages and went exploring in the code to understand why it was so much chattier than my previous Consul deployment, and what I found became this PR.

There's a detailed explanation in each commit here (especially note the RBAC changes required by the first commit), but the upshot of the changes is that we can use Endpoint objects directly to avoid having to find the gNMIc pods ourselves. We get some extra benefits for free with Endpoints: non-ready pod addresses get removed from the cluster's discovered services without us having to do the work of finding them. We can then use "watches" on these objects instead of scraping them repeatedly, which gives us realtimeish detection of changes and -- ultimately what I was looking for -- a quiet log stream in the steady state because we only send updates when things actually change.

I did not see any documentation for the K8s locker yet, but if I just missed it, that will need to be updated too.

This is my first time both with the Kubernetes API and with any nontrivial amount of Go code, so don't be shy about being critical if I've done something wrong.