### PR TITLE
Redact target passwords

### DIFF
--- a/app/target.go
+++ b/app/target.go
@@ -89,7 +89,7 @@ func (a *App) DeleteTarget(ctx context.Context, name string) error {
 
 // AddTargetConfig adds a *TargetConfig to the configuration map
 func (a *App) AddTargetConfig(tc *types.TargetConfig) {
-	a.Logger.Printf("adding target %+v", tc)
+	a.Logger.Printf("adding target %s", tc)
 	_, ok := a.Config.Targets[tc.Name]
 	if ok {
 		return

--- a/loaders/file_loader/file_loader.go
+++ b/loaders/file_loader/file_loader.go
@@ -251,7 +251,7 @@ func (f *fileLoader) getTargets(ctx context.Context) (map[string]*types.TargetCo
 			t.Address = n
 		}
 	}
-	f.logger.Printf("result: %v", result)
+	f.logger.Printf("result: %s", result)
 	return result, nil
 }
 

--- a/loaders/http_loader/http_loader.go
+++ b/loaders/http_loader/http_loader.go
@@ -271,7 +271,7 @@ func (h *httpLoader) getTargets() (map[string]*types.TargetConfig, error) {
 			t.Address = n
 		}
 	}
-	h.logger.Printf("result: %v", result)
+	h.logger.Printf("result: %s", result)
 	return result, nil
 }
 

--- a/types/target.go
+++ b/types/target.go
@@ -49,7 +49,16 @@ type TargetConfig struct {
 }
 
 func (tc *TargetConfig) String() string {
-	b, err := json.Marshal(tc)
+	var redacted_tc *TargetConfig
+	if tc.Password == nil {
+		redacted_tc = tc
+	} else {
+		redacted_tc = new(TargetConfig)
+		*redacted_tc = *tc
+		password := "****"
+		redacted_tc.Password = &password
+	}
+	b, err := json.Marshal(redacted_tc)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
Hi again. Quick one this time. My file loader config includes unique passwords for different subsets of devices, and since the loaders log the list of targets they created, the passwords end up in the log stream. What I've done here is simply implement a MarshalJSON() method to replace the password field with `****`. It works, but I have no idea how unwise this is. Is there anywhere else in the application where these structs get written as JSON (eg., to disk) that this will break?