### PR TITLE
refactored target config password redaction

### DIFF
--- a/types/target.go
+++ b/types/target.go
@@ -48,20 +48,16 @@ type TargetConfig struct {
 	TunnelTargetType string `mapstructure:"-" json:"tunnel-target-type,omitempty" yaml:"tunnel-target-type,omitempty"`
 }
 
-func (tc *TargetConfig) String() string {
-	var redacted_tc *TargetConfig
-	if tc.Password == nil {
-		redacted_tc = tc
-	} else {
-		redacted_tc = new(TargetConfig)
-		*redacted_tc = *tc
-		password := "****"
-		redacted_tc.Password = &password
+func (tc TargetConfig) String() string {
+	if tc.Password != nil {
+		*tc.Password = "****"
 	}
-	b, err := json.Marshal(redacted_tc)
+	
+	b, err := json.Marshal(tc)
 	if err != nil {
 		return ""
 	}
+
 	return string(b)
 }
 

--- a/types/target.go
+++ b/types/target.go
@@ -50,7 +50,8 @@ type TargetConfig struct {
 
 func (tc TargetConfig) String() string {
 	if tc.Password != nil {
-		*tc.Password = "****"
+		pwd := "****"
+		tc.Password = &pwd
 	}
 	
 	b, err := json.Marshal(tc)


### PR DESCRIPTION
could be a cleaner (?) version of #634 
pointer receiver changed to value receiver ([repl](https://replit.com/@RomanDodin/RealOldfashionedConsulting#main.go))